### PR TITLE
Refactor getMove to return optional

### DIFF
--- a/include/lilia/model/chess_game.hpp
+++ b/include/lilia/model/chess_game.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <optional>
 
 #include "../constants.hpp"
 #include "move_generator.hpp"
@@ -24,7 +25,7 @@ class ChessGame {
   bb::Piece getPiece(core::Square sq);
   const GameState& getGameState();
   std::vector<Move> generateLegalMoves();
-  const Move& getMove(core::Square from, core::Square to);
+  std::optional<Move> getMove(core::Square from, core::Square to);
   bool isKingInCheck(core::Color from) const;
   core::Square getRookSquareFromCastleside(CastleSide castleSide, core::Color side);
   core::Square getKingSquare(core::Color color);

--- a/src/lilia/model/chess_game.cpp
+++ b/src/lilia/model/chess_game.cpp
@@ -1,6 +1,7 @@
 #include "lilia/model/chess_game.hpp"
 
 #include <sstream>
+#include <optional>
 
 namespace lilia::model {
 
@@ -54,13 +55,12 @@ void ChessGame::doMoveUCI(const std::string& uciMove) {
   doMove(from, to, promo);
 }
 
-const Move& ChessGame::getMove(core::Square from, core::Square to) {
-  int side = bb::ci(m_position.state().sideToMove);
+std::optional<Move> ChessGame::getMove(core::Square from, core::Square to) {
   std::vector<Move> moves = generateLegalMoves();
-  for (auto& m : moves)
+  for (const auto& m : moves) {
     if (m.from == from && m.to == to) return m;
-
-  return Move{};
+  }
+  return std::nullopt;
 }
 
 void ChessGame::setPosition(const std::string& fen) {


### PR DESCRIPTION
## Summary
- change ChessGame::getMove to return std::optional<Move>
- copy and return move object, return std::nullopt when not found

## Testing
- `cmake -S . -B build` *(fails: unable to access https://github.com/SFML/SFML.git)*


------
https://chatgpt.com/codex/tasks/task_e_68ad2df011c88329ad5ca7ec052f0b09