### PR TITLE
Reduce data copying in model and engine

### DIFF
--- a/include/lilia/engine/bot_engine.hpp
+++ b/include/lilia/engine/bot_engine.hpp
@@ -31,7 +31,7 @@ class BotEngine {
                             std::atomic<bool>* externalCancel = nullptr);
 
   // Direkt zugänglich, falls jemand Stats separat lesen will
-  engine::SearchStats getLastSearchStats() const;
+  const engine::SearchStats& getLastSearchStats() const;
 
  private:
   Engine m_engine;

--- a/include/lilia/engine/engine.hpp
+++ b/include/lilia/engine/engine.hpp
@@ -23,8 +23,8 @@ class Engine {
   }
   std::optional<model::Move> find_best_move(model::Position& pos, int maxDepth = 8,
                                             std::atomic<bool>* stop = nullptr);
-  SearchStats getLastSearchStats() const;
-  EngineConfig getConfig() const;
+  const SearchStats& getLastSearchStats() const;
+  const EngineConfig& getConfig() const;
 
  private:
   struct Impl;

--- a/include/lilia/engine/search.hpp
+++ b/include/lilia/engine/search.hpp
@@ -52,8 +52,8 @@ class Search {
   int search_root_parallel(model::Position& pos, int depth, std::atomic<bool>* stop,
                            int maxThreads = 0);
 
-  // get snapshot of stats
-  SearchStats getStatsCopy() const;
+  // access current stats without copying
+  const SearchStats& getStats() const;
 
   // clear/initialize search internal state (killers/history/stats)
   void clearSearchState();

--- a/include/lilia/model/chess_game.hpp
+++ b/include/lilia/model/chess_game.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "../constants.hpp"
 #include "move_generator.hpp"
@@ -23,8 +24,8 @@ class ChessGame {
 
   bb::Piece getPiece(core::Square sq);
   const GameState& getGameState();
-  std::vector<Move> generateLegalMoves();
-  const Move& getMove(core::Square from, core::Square to);
+  const std::vector<Move>& generateLegalMoves();
+  Move getMove(core::Square from, core::Square to);
   bool isKingInCheck(core::Color from) const;
   core::Square getRookSquareFromCastleside(CastleSide castleSide, core::Color side);
   core::Square getKingSquare(core::Color color);
@@ -37,6 +38,8 @@ class ChessGame {
   MoveGenerator m_move_gen;
   Position m_position;
   core::GameResult m_result;
+  std::vector<Move> m_pseudo_moves;
+  std::vector<Move> m_legal_moves;
 };
 
 }  // namespace lilia::model

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -160,7 +160,7 @@ void GameController::snapAndReturn(core::Square sq, core::MousePos cur) {
 }
 
 [[nodiscard]] bool GameController::isPromotion(core::Square a, core::Square b) {
-  for (auto m : m_chess_game.generateLegalMoves()) {
+  for (const auto& m : m_chess_game.generateLegalMoves()) {
     if (m.from == a && m.to == b && m.promotion != core::PieceType::None) return true;
   }
   return false;
@@ -172,7 +172,7 @@ void GameController::snapAndReturn(core::Square sq, core::MousePos cur) {
 [[nodiscard]] std::vector<core::Square> GameController::getAttackSquares(
     core::Square pieceSQ) const {
   std::vector<core::Square> att;
-  for (auto m : m_chess_game.generateLegalMoves()) {
+  for (const auto& m : m_chess_game.generateLegalMoves()) {
     if (m.from == pieceSQ) att.push_back(m.to);
   }
   return att;

--- a/src/lilia/engine/bot_engine.cpp
+++ b/src/lilia/engine/bot_engine.cpp
@@ -129,7 +129,7 @@ SearchResult BotEngine::findBestMove(model::ChessGame& gameState, int maxDepth, 
   return res;
 }
 
-SearchStats BotEngine::getLastSearchStats() const {
+const SearchStats& BotEngine::getLastSearchStats() const {
   return m_engine.getLastSearchStats();
 }
 

--- a/src/lilia/engine/engine.cpp
+++ b/src/lilia/engine/engine.cpp
@@ -36,13 +36,13 @@ std::optional<model::Move> Engine::find_best_move(model::Position& pos, int maxD
 
   pimpl->search->search_root_parallel(pos, maxDepth, stop, pimpl->cfg.threads);
 
-  return pimpl->search->getStatsCopy().bestMove;
+  return pimpl->search->getStats().bestMove;
 }
 
-SearchStats Engine::getLastSearchStats() const {
-  return pimpl->search->getStatsCopy();
+const SearchStats& Engine::getLastSearchStats() const {
+  return pimpl->search->getStats();
 }
-EngineConfig Engine::getConfig() const {
+const EngineConfig& Engine::getConfig() const {
   return pimpl->cfg;
 }
 

--- a/src/lilia/engine/search.cpp
+++ b/src/lilia/engine/search.cpp
@@ -417,7 +417,7 @@ int Search::search_root_parallel(model::Position& pos, int depth, std::atomic<bo
         int score = -worker.negamax(child, depth - 1, -INF, INF, 1, ref);
         rr.score = score;
         rr.move = std::move(m);
-        rr.stats = worker.getStatsCopy();
+        rr.stats = worker.getStats();
         p.set_value(std::move(rr));
       } catch (const SearchStoppedException& e) {
         std::cout << "spawn worker search stopped" << std::endl;
@@ -550,7 +550,7 @@ int Search::search_root_parallel(model::Position& pos, int depth, std::atomic<bo
 }
 
 // snapshot stats
-SearchStats Search::getStatsCopy() const {
+const SearchStats& Search::getStats() const {
   return stats;
 }
 

--- a/src/lilia/model/chess_game.cpp
+++ b/src/lilia/model/chess_game.cpp
@@ -54,10 +54,9 @@ void ChessGame::doMoveUCI(const std::string& uciMove) {
   doMove(from, to, promo);
 }
 
-const Move& ChessGame::getMove(core::Square from, core::Square to) {
-  int side = bb::ci(m_position.state().sideToMove);
-  std::vector<Move> moves = generateLegalMoves();
-  for (auto& m : moves)
+Move ChessGame::getMove(core::Square from, core::Square to) {
+  const auto& moves = generateLegalMoves();
+  for (const auto& m : moves)
     if (m.from == from && m.to == to) return m;
 
   return Move{};
@@ -144,18 +143,17 @@ void ChessGame::buildHash() {
   m_position.buildHash();
 }
 
-std::vector<Move> ChessGame::generateLegalMoves() {
-  int side = bb::ci(m_position.state().sideToMove);
-  std::vector<Move> pseudo;
-  m_move_gen.generatePseudoLegalMoves(m_position.board(), m_position.state(), pseudo);
-  std::vector<Move> legalMoves;
-  for (const auto& m : pseudo) {
+const std::vector<Move>& ChessGame::generateLegalMoves() {
+  m_pseudo_moves.clear();
+  m_legal_moves.clear();
+  m_move_gen.generatePseudoLegalMoves(m_position.board(), m_position.state(), m_pseudo_moves);
+  for (const auto& m : m_pseudo_moves) {
     if (m_position.doMove(m)) {
       m_position.undoMove();
-      legalMoves.push_back(m);
+      m_legal_moves.push_back(m);
     }
   }
-  return legalMoves;
+  return m_legal_moves;
 }
 
 const GameState& ChessGame::getGameState() {
@@ -207,7 +205,7 @@ bb::Piece ChessGame::getPiece(core::Square sq) {
 }
 
 void ChessGame::doMove(core::Square from, core::Square to, core::PieceType promotion) {
-  for (auto m : generateLegalMoves())
+  for (const auto& m : generateLegalMoves())
     if (m.from == from && m.to == to && m.promotion == promotion) m_position.doMove(m);
 }
 


### PR DESCRIPTION
## Summary
- Generate and reuse legal moves in `ChessGame` without returning copies
- Expose engine stats and config via const references to reduce copying
- Iterate over move lists by reference to avoid per-move copies

## Testing
- `cmake -S . -B build` *(fails: unable to clone SFML dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3242fa8c832991f2a0aeb9dc3cd8