### PR TITLE
Allow configuring bot search depth and think time from app input

### DIFF
--- a/include/lilia/app/app.hpp
+++ b/include/lilia/app/app.hpp
@@ -16,6 +16,10 @@ class App {
   // Read start options from terminal; empty input -> defaults
   void promptStartOptions();
 
+  // input helper: parse integer with defaults and bounds
+  static int parseIntInRange(const std::string& s, int defaultVal, int minVal,
+                             int maxVal);
+
   // helpers
   static std::string trim(const std::string& s);
   static std::string toLower(const std::string& s);
@@ -25,6 +29,8 @@ class App {
   core::Color m_playerColor = core::Color::White;
   bool m_vsBot = true;
   std::string m_startFen;
+  int m_thinkTimeMs = 1000;  // Bot think time in milliseconds
+  int m_searchDepth = 5;     // Search depth for bot
 };
 
 }  // namespace lilia::app

--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -62,9 +62,11 @@ class GameController {
    * @param playerColor Farbe des menschlichen Spielers (default: White).
    * @param fen Start-FEN (default: START_FEN).
    * @param vsBot true = Gegner ist Bot, false = menschlicher Gegner.
+   * @param thinkTimeMs Zeit in Millisekunden, die der Bot maximal denken darf.
+   * @param depth Suchtiefe für den Bot.
    */
   void startGame(core::Color playerColor, const std::string& fen = core::START_FEN,
-                 bool vsBot = true);
+                 bool vsBot = true, int thinkTimeMs = 1000, int depth = 5);
 
  private:
   // ---------------- Input handlers ----------------

--- a/include/lilia/controller/game_manager.hpp
+++ b/include/lilia/controller/game_manager.hpp
@@ -34,7 +34,7 @@ class GameManager {
 
   // Lifecycle
   void startGame(core::Color playerColor, const std::string& fen = core::START_FEN,
-                 bool vsBot = true);
+                 bool vsBot = true, int thinkTimeMs = 1000, int depth = 5);
   void stopGame();
 
   // Called each frame from main loop: Polls bot futures and applies moves when ready.

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -35,6 +35,16 @@ bool App::parseYesNoDefaultTrue(const std::string& s) {
   return true;
 }
 
+int App::parseIntInRange(const std::string& s, int defaultVal, int minVal, int maxVal) {
+  std::string t = trim(s);
+  if (t.empty()) return defaultVal;
+  if (!std::all_of(t.begin(), t.end(), [](unsigned char c) { return std::isdigit(c); }))
+    return -1;
+  int val = std::stoi(t);
+  if (val < minVal || val > maxVal) return -1;
+  return val;
+}
+
 void App::promptStartOptions() {
   std::cout << "Player color (white / black) [Standard: white]: ";
   std::string colorInput;
@@ -63,6 +73,32 @@ void App::promptStartOptions() {
   } else {
     m_startFen = fenInput;  // use exactly what the user typed (trimmed)
   }
+
+  // Think time in seconds
+  while (true) {
+    std::cout << "Bot think time in seconds [Standard: 1]: ";
+    std::string thinkInput;
+    std::getline(std::cin, thinkInput);
+    int val = parseIntInRange(thinkInput, 1, 1, 60);
+    if (val != -1) {
+      m_thinkTimeMs = val * 1000;  // convert to ms
+      break;
+    }
+    std::cout << "Please enter a number between 1 and 60.\n";
+  }
+
+  // Search depth
+  while (true) {
+    std::cout << "Bot search depth [Standard: 5]: ";
+    std::string depthInput;
+    std::getline(std::cin, depthInput);
+    int val = parseIntInRange(depthInput, 5, 1, 20);
+    if (val != -1) {
+      m_searchDepth = val;
+      break;
+    }
+    std::cout << "Please enter a number between 1 and 20.\n";
+  }
 }
 
 int App::run() {
@@ -85,7 +121,8 @@ int App::run() {
     lilia::controller::GameController gController(view, chessgame);
 
     // start the game using GameController wrapper that delegates to GameManager
-    gController.startGame(m_playerColor, m_startFen, m_vsBot);
+    gController.startGame(m_playerColor, m_startFen, m_vsBot, m_thinkTimeMs,
+                          m_searchDepth);
 
     // main loop
     sf::Clock clock;

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -41,10 +41,11 @@ GameController::GameController(view::GameView& gView, model::ChessGame& game)
   });
 }
 
-void GameController::startGame(core::Color playerColor, const std::string& fen, bool vsBot) {
+void GameController::startGame(core::Color playerColor, const std::string& fen, bool vsBot,
+                               int thinkTimeMs, int depth) {
   m_sound_manager.playGameBegins();
   m_gameView.init(fen);
-  m_gameManager->startGame(playerColor, fen, vsBot);
+  m_gameManager->startGame(playerColor, fen, vsBot, thinkTimeMs, depth);
 }
 
 void GameController::handleEvent(const sf::Event& event) {

--- a/src/lilia/controller/game_manager.cpp
+++ b/src/lilia/controller/game_manager.cpp
@@ -10,23 +10,22 @@ GameManager::~GameManager() {
   stopGame();
 }
 
-void GameManager::startGame(core::Color playerColor, const std::string& fen, bool vsBot) {
+void GameManager::startGame(core::Color playerColor, const std::string& fen, bool vsBot,
+                            int thinkTimeMs, int depth) {
   std::lock_guard lock(m_mutex);
   m_playerColor = playerColor;
   m_game.setPosition(fen);
   m_cancelBot.store(false);
   m_waitingPromotion = false;
-  int thinkTime = 5000;  // ms
-  int depth = 2;
 
   // default: human for player color, bot for opponent (if vsBot)
   if (vsBot) {
     if (playerColor == core::Color::White) {
       m_whitePlayer.reset();  // human
-      m_blackPlayer = std::make_unique<BotPlayer>(thinkTime, depth);
+      m_blackPlayer = std::make_unique<BotPlayer>(thinkTimeMs, depth);
     } else {
       m_blackPlayer.reset();
-      m_whitePlayer = std::make_unique<BotPlayer>(thinkTime, depth);
+      m_whitePlayer = std::make_unique<BotPlayer>(thinkTimeMs, depth);
     }
 
   } else {


### PR DESCRIPTION
## Summary
- Prompt for bot think time and search depth at app start with validation and defaults
- Forward think time (ms) and depth through controller into GameManager
- Use provided configuration when creating BotPlayer

## Testing
- `cmake ..` *(fails: CONNECT tunnel failed to https://github.com/SFML/SFML.git)*

------
https://chatgpt.com/codex/tasks/task_e_68ad369edf1c8329b1c5edf13411586a