### PR TITLE
Add executable UCI options and basic time management

### DIFF
--- a/include/lilia/engine/bot_engine.hpp
+++ b/include/lilia/engine/bot_engine.hpp
@@ -22,7 +22,7 @@ struct SearchResult {
 
 class BotEngine {
  public:
-  BotEngine();
+  explicit BotEngine(const EngineConfig& cfg = {});
   ~BotEngine();
 
   // Führe die Suche aus. thinkMillis = max Denkzeit in ms (0 = no timer).

--- a/include/lilia/uci/uci.hpp
+++ b/include/lilia/uci/uci.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 
+#include "lilia/engine/config.hpp"
 #include "lilia/model/chess_game.hpp"
 
 namespace lilia {
@@ -13,6 +14,19 @@ class UCI {
  private:
   void showOptions();
   void setOption(const std::string& line);
+
+  struct Options {
+    int hashMb = 64;
+    int threads = 1;
+    bool ponder = false;
+    int moveOverhead = 10;
+    engine::EngineConfig toEngineConfig() const {
+      engine::EngineConfig cfg;
+      cfg.ttSizeMb = hashMb;
+      cfg.threads = threads;
+      return cfg;
+    }
+  } m_options;
 
   std::string m_name = "LiliaEngine";
   std::string m_version = "1.0";

--- a/src/lilia/engine/bot_engine.cpp
+++ b/src/lilia/engine/bot_engine.cpp
@@ -10,7 +10,7 @@
 
 namespace lilia::engine {
 
-BotEngine::BotEngine() : m_engine() {}
+BotEngine::BotEngine(const EngineConfig& cfg) : m_engine(cfg) {}
 BotEngine::~BotEngine() = default;
 
 static inline std::string format_top_moves(const std::vector<std::pair<model::Move, int>>& top) {

--- a/src/lilia/uci/uci.cpp
+++ b/src/lilia/uci/uci.cpp
@@ -6,7 +6,6 @@
 #include <chrono>
 #include <future>
 #include <iostream>
-#include <map>
 #include <mutex>
 #include <sstream>
 #include <string>
@@ -39,9 +38,14 @@ static std::string extract_fen_after(const std::string& line) {
 }
 
 void UCI::showOptions() {
-  std::cout << "option name Hash type spin default 64 min 1 max 131072\n";
-  std::cout << "option name Threads type spin default 1 min 1 max 64\n";
-  std::cout << "option name Ponder type check default false\n";
+  std::cout << "option name Hash type spin default " << m_options.hashMb
+            << " min 1 max 131072\n";
+  std::cout << "option name Threads type spin default " << m_options.threads
+            << " min 1 max 64\n";
+  std::cout << "option name Ponder type check default "
+            << (m_options.ponder ? "true" : "false") << "\n";
+  std::cout << "option name Move Overhead type spin default "
+            << m_options.moveOverhead << " min 0 max 5000\n";
 }
 
 void UCI::setOption(const std::string& line) {
@@ -70,13 +74,28 @@ void UCI::setOption(const std::string& line) {
   }
   if (name.empty()) return;
 
-  static std::map<std::string, std::string> options;
-  options[name] = value;
-  // optional: map options to engine config if you expose setters later
+
+  if (name == "Hash") {
+    int v = std::stoi(value);
+    v = std::max(1, std::min(131072, v));
+    m_options.hashMb = v;
+  } else if (name == "Threads") {
+    int v = std::stoi(value);
+    v = std::max(1, std::min(64, v));
+    m_options.threads = v;
+  } else if (name == "Ponder") {
+    std::string vl = value;
+    std::transform(vl.begin(), vl.end(), vl.begin(), [](unsigned char c) { return std::tolower(c); });
+    m_options.ponder = (vl == "true" || vl == "1" || vl == "on");
+  } else if (name == "Move Overhead") {
+    int v = std::stoi(value);
+    m_options.moveOverhead = std::max(0, v);
+  }
 }
 
 // UCI run: verwendet BotEngine direkt (kein controller)
 int UCI::run() {
+  engine::Engine::init();
   std::string line;
 
   // search state
@@ -99,6 +118,7 @@ int UCI::run() {
 
     if (cmd == "uci") {
       std::cout << "id name " << m_name << "\n";
+      std::cout << "id author unknown\n";
       std::cout << "id version " << m_version << "\n";
       showOptions();
       std::cout << "uciok\n";
@@ -148,14 +168,28 @@ int UCI::run() {
     if (cmd == "go") {
       int depth = -1;
       int movetime = -1;
+      int wtime = -1, btime = -1, winc = 0, binc = 0, movestogo = 0;
       bool infinite = false;
+      bool ponder = false;
       for (size_t i = 1; i < tokens.size(); ++i) {
         if (tokens[i] == "depth" && i + 1 < tokens.size()) {
           depth = std::stoi(tokens[++i]);
         } else if (tokens[i] == "movetime" && i + 1 < tokens.size()) {
           movetime = std::stoi(tokens[++i]);
+        } else if (tokens[i] == "wtime" && i + 1 < tokens.size()) {
+          wtime = std::stoi(tokens[++i]);
+        } else if (tokens[i] == "btime" && i + 1 < tokens.size()) {
+          btime = std::stoi(tokens[++i]);
+        } else if (tokens[i] == "winc" && i + 1 < tokens.size()) {
+          winc = std::stoi(tokens[++i]);
+        } else if (tokens[i] == "binc" && i + 1 < tokens.size()) {
+          binc = std::stoi(tokens[++i]);
+        } else if (tokens[i] == "movestogo" && i + 1 < tokens.size()) {
+          movestogo = std::stoi(tokens[++i]);
         } else if (tokens[i] == "infinite") {
           infinite = true;
+        } else if (tokens[i] == "ponder") {
+          ponder = true;
         }
       }
 
@@ -170,28 +204,42 @@ int UCI::run() {
         }
       }
 
-      // determine time to think (milliseconds). If movetime given use it, else if infinite use 0
-      // (no timer), else 0
-      int thinkMillis = (movetime > 0 ? movetime : 0);
+      // determine think time
+      int thinkMillis = 0;
+      if (movetime > 0)
+        thinkMillis = movetime;
+      else if (!infinite && !(ponder && m_options.ponder)) {
+        int timeLeft =
+            (m_game.getGameState().sideToMove == core::Color::White ? wtime : btime);
+        int inc = (m_game.getGameState().sideToMove == core::Color::White ? winc : binc);
+        if (timeLeft >= 0) {
+          if (movestogo > 0)
+            thinkMillis = timeLeft / movestogo;
+          else
+            thinkMillis = timeLeft / 30;
+          thinkMillis += inc;
+          thinkMillis -= m_options.moveOverhead;
+          if (thinkMillis < 0) thinkMillis = 0;
+        }
+      }
 
-      // Start asynchronous search using engine::BotEngine synchronously inside async
       cancelToken.store(false);
       {
         std::lock_guard<std::mutex> lk(stateMutex);
-        // use std::async to run the engine call in background
+        auto cfg = m_options.toEngineConfig();
         searchFuture = std::async(
-            std::launch::async, [this, depth, thinkMillis, &cancelToken]() -> model::Move {
-              lilia::engine::BotEngine engine;
-              auto res = engine.findBestMove(const_cast<model::ChessGame&>(m_game),
-                                             (depth > 0 ? depth : /*some default*/ 0), thinkMillis,
-                                             &cancelToken);
+            std::launch::async,
+            [this, depth, thinkMillis, &cancelToken, cfg]() -> model::Move {
+              lilia::engine::BotEngine engine(cfg);
+              auto res = engine.findBestMove(m_game,
+                                             (depth > 0 ? depth : /*some default*/ 0),
+                                             thinkMillis, &cancelToken);
               if (res.bestMove.has_value()) return res.bestMove.value();
-              return model::Move{};  // invalid move if none
+              return model::Move{};
             });
 
         searchRunning = true;
 
-        // printer thread: wait for future and print bestmove
         printerThread = std::thread([&searchFuture, &stateMutex, &searchRunning, &cancelToken]() {
           model::Move best;
           try {
@@ -203,9 +251,6 @@ int UCI::run() {
           if (best.from >= 0 && best.to >= 0) {
             std::cout << "bestmove " << move_to_uci(best) << "\n";
           } else {
-            // UCI requires a move; if none found, send bestmove with invalid (but better send
-            // resign?) We'll send bestmove 0000 (some GUIs might treat it as invalid) —
-            // alternative: pick a legal move before returning.
             std::cout << "bestmove 0000\n";
           }
 
@@ -222,6 +267,19 @@ int UCI::run() {
 
     if (cmd == "stop") {
       cancelToken.store(true);
+      {
+        std::lock_guard<std::mutex> lk(stateMutex);
+        if (searchRunning && printerThread.joinable()) {
+          printerThread.join();
+          searchRunning = false;
+          cancelToken.store(false);
+        }
+      }
+      continue;
+    }
+
+    if (cmd == "ponderhit") {
+      // no special handling needed in this simple engine
       continue;
     }
 


### PR DESCRIPTION
## Summary
- allow UCI to configure Hash, Threads, Ponder and Move Overhead options
- apply configured options to engine and compute thinking time from wtime/btime inputs
- ensure engine is initialised and search threads stop cleanly
- clean up UCI option handling and remove unnecessary const_cast

## Testing
- `cmake -S . -B build` *(fails: unable to clone SFML repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3ac96c348329a22a118dfbd6dd54