### PR TITLE
Optimize release build and document architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,19 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # -------------------------------------------------------------
+# Optimised release flags
+# -------------------------------------------------------------
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -march=native")
+elseif(MSVC)
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /O2")
+endif()
+
+# -------------------------------------------------------------
 # Sources (Core: immer)
 # -------------------------------------------------------------
 file(GLOB_RECURSE MODEL_FILES     ${PROJECT_SOURCE_DIR}/src/lilia/model/*.cpp)

--- a/README.md
+++ b/README.md
@@ -20,29 +20,52 @@ This is a chess engine written from scratch in C++ with a graphical user interfa
 
 ### Steps to Build
 
-1. **Run CMake Commands**:
-   - Open a terminal/command prompt.
-   - Navigate to your project directory.
-   
-   Run the following commands to configure and build the project:
-   
+1. **Open the MinGW64 shell** and navigate to the folder where you want to place the project.
+
+   ```bash
+   git clone <repo-url>
+   cd Chess-Engine
+   ```
+
+2. **Configure and build** the engine in release mode with optimisation flags:
+
    ```bash
    cmake -S . -B build
    cmake --build build --config Release
    ```
-   
-   This will:
-   - Generate the build configuration in the `build/` directory.
-   - Compile the project in release mode.
-   
-2. **Locate the Executable**:
-   - After the build process completes, the executable file `ChessEngine_Lilia-VERSION.exe` will be created in the `build/Release/` directory.
 
-3. **Run the Engine**:
-   - You can now run the latest version of the chess engine, which will be located in the `build/Release/` directory.
+   These commands generate a `build/` directory and compile an optimised release binary.
+
+3. **Run the engine**:
+
+   ```bash
+   build/Release/ChessEngine_Lilia-VERSION.exe
+   ```
+
+   The executable lives in `build/Release/` after a successful build.
 
 ---
 
 ## Notes
 
 - This setup is currently optimized for **Windows 64-bit** architecture.
+
+---
+
+## Architecture & Design Patterns
+
+The project is structured around a clear separation of responsibilities:
+
+- **Model** – core chess logic such as the board representation, move generation and evaluation (`include/lilia/model`, `src/lilia/model`).
+- **View** – SFML-based rendering layer (`include/lilia/view`, `src/lilia/view`). `GameView` acts as a façade over SFML, while textures are managed by the Singleton `TextureTable`.
+- **Controller** – orchestrates user input and the game loop (`include/lilia/controller`, `src/lilia/controller`). `GameManager` exposes callbacks for moves, promotions and game end events, enabling an observer-style communication with the view.
+- **Engine** – search and evaluation algorithms for AI play (`include/lilia/engine`, `src/lilia/engine`).
+
+Design patterns used include:
+
+- **Model–View–Controller** to separate state, presentation and interaction.
+- **Strategy** via the `IPlayer` interface, allowing interchangeable bot or human move providers.
+- **Singleton** for central texture management (`TextureTable`).
+- **Observer-like callbacks** from `GameManager` to notify other components of state changes.
+- **Factory** to generate fresh evaluator instances for each search thread (`EvalFactory`).
+- **Facade** through `GameView`, which offers a simplified interface to the rendering subsystem.


### PR DESCRIPTION
## Summary
- enable Release as default build type with extra optimization flags
- clarify exact Windows build commands and executable location
- document overall architecture and design patterns (including Factory and Facade)

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY OPENGL_INCLUDE_DIR))*

------
https://chatgpt.com/codex/tasks/task_e_68ad3f57bd80832994fbe8616b100d36