### PR TITLE
feat: prevent dragging pieces outside window

### DIFF
--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/System/Vector2.hpp>
+
 #include "../constants.hpp"
 #include "../controller/mousepos.hpp"
 #include "animation/chess_animator.hpp"
@@ -26,6 +29,9 @@ class GameView {
   [[nodiscard]] core::Square mousePosToSquare(core::MousePos mousePos) const;
   void setPieceToMouseScreenPos(core::Square pos, core::MousePos mousePos);
   void setPieceToSquareScreenPos(core::Square from, core::Square to);
+
+  [[nodiscard]] sf::Vector2u getWindowSize() const;
+  [[nodiscard]] Entity::Position getPieceSize(core::Square pos) const;
 
   [[nodiscard]] bool hasPieceOnSquare(core::Square pos) const;
   [[nodiscard]] bool isSameColorPiece(core::Square sq1, core::Square sq2) const;

--- a/include/lilia/view/piece_manager.hpp
+++ b/include/lilia/view/piece_manager.hpp
@@ -27,6 +27,7 @@ class PieceManager {
   void removeAll();
 
   [[nodiscard]] bool hasPieceOnSquare(core::Square pos) const;
+  [[nodiscard]] Entity::Position getPieceSize(core::Square pos) const;
   void setPieceToSquareScreenPos(core::Square from, core::Square to);
   void setPieceToScreenPos(core::Square pos, core::MousePos mousePos);
   void setPieceToScreenPos(core::Square pos, Entity::Position entityPos);

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -2,6 +2,7 @@
 
 #include <SFML/System/Sleep.hpp>
 #include <SFML/System/Time.hpp>
+#include <algorithm>
 #include <iostream>
 #include <string>
 
@@ -258,7 +259,18 @@ void GameController::onDrag(core::MousePos start, core::MousePos current) {
 
   hoverSquare(sqMous);
 
-  m_game_view.setPieceToMouseScreenPos(sqStart, current);
+  auto size = m_game_view.getPieceSize(sqStart);
+  auto window = m_game_view.getWindowSize();
+  float halfW = size.x / 2.f;
+  float halfH = size.y / 2.f;
+  float clampedX =
+      std::clamp(static_cast<float>(current.x), halfW, static_cast<float>(window.x) - halfW);
+  float clampedY =
+      std::clamp(static_cast<float>(current.y), halfH, static_cast<float>(window.y) - halfH);
+  core::MousePos clamped{static_cast<unsigned int>(clampedX),
+                         static_cast<unsigned int>(clampedY)};
+
+  m_game_view.setPieceToMouseScreenPos(sqStart, clamped);
   m_game_view.playPiecePlaceHolderAnimation(sqStart);
 }
 

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -159,4 +159,10 @@ void GameView::setPieceToSquareScreenPos(core::Square from, core::Square to) {
   m_piece_manager.setPieceToSquareScreenPos(from, to);
 }
 
+sf::Vector2u GameView::getWindowSize() const { return m_window.getSize(); }
+
+Entity::Position GameView::getPieceSize(core::Square pos) const {
+  return m_piece_manager.getPieceSize(pos);
+}
+
 }  

--- a/src/lilia/view/piece_manager.cpp
+++ b/src/lilia/view/piece_manager.cpp
@@ -105,6 +105,12 @@ void PieceManager::removeAll() {
   return m_pieces.find(pos) != m_pieces.end();
 }
 
+Entity::Position PieceManager::getPieceSize(core::Square pos) const {
+  auto it = m_pieces.find(pos);
+  if (it == m_pieces.end()) return {0.f, 0.f};
+  return it->second.getCurrentSize();
+}
+
 [[nodiscard]] inline Entity::Position mouseToEntityPos(core::MousePos mousePos) {
   return static_cast<Entity::Position>(mousePos);
 }


### PR DESCRIPTION
## Summary
- expose window and piece size from GameView/PieceManager
- clamp dragged piece position to stay inside window borders

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: undefined reference to XConvertSelection, XUnsetICFocus, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7d46748c8329be6da456529aeb6d