### PR TITLE
Fix drag logic so click and promotion moves work

### DIFF
--- a/src/lilia/controller/input_manager.cpp
+++ b/src/lilia/controller/input_manager.cpp
@@ -24,7 +24,8 @@ void InputManager::processEvent(const sf::Event& event) {
       if (event.mouseButton.button == sf::Mouse::Left) {
         m_drag_start = core::MousePos(event.mouseButton.x, event.mouseButton.y);
         m_dragging = true;
-        if (!m_moved) m_on_drag(m_drag_start.value(), m_drag_start.value());
+        m_moved = false;
+        if (m_on_drag) m_on_drag(m_drag_start.value(), m_drag_start.value());
       }
       break;
 
@@ -40,7 +41,11 @@ void InputManager::processEvent(const sf::Event& event) {
     case sf::Event::MouseButtonReleased:
       if (event.mouseButton.button == sf::Mouse::Left && m_dragging && m_drag_start) {
         core::MousePos dropPos(event.mouseButton.x, event.mouseButton.y);
-        if (m_on_drop) m_on_drop(m_drag_start.value(), dropPos);
+        if (isClick(m_drag_start.value(), dropPos)) {
+          if (m_on_click) m_on_click(dropPos);
+        } else {
+          if (m_on_drop) m_on_drop(m_drag_start.value(), dropPos);
+        }
 
         m_drag_start.reset();
         m_dragging = false;


### PR DESCRIPTION
## Summary
- Distinguish click from drag in `InputManager` so click actions and promotion selection work again
- Trigger drag on mouse press and click on release when no meaningful movement occurs

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68ae100db04483298f479529b724b02c