### PR TITLE
Handle stationary drag via duration

### DIFF
--- a/include/lilia/controller/input_manager.hpp
+++ b/include/lilia/controller/input_manager.hpp
@@ -13,29 +13,37 @@ class Event;
 namespace lilia::controller {
 
 class InputManager {
- public:
+public:
   using ClickCallback = std::function<void(core::MousePos)>;
 
-  using DragCallback = std::function<void(core::MousePos start, core::MousePos current)>;
+  using DragCallback =
+      std::function<void(core::MousePos start, core::MousePos current)>;
 
-  using DropCallback = std::function<void(core::MousePos start, core::MousePos end)>;
+  using DropCallback =
+      std::function<void(core::MousePos start, core::MousePos end)>;
 
   void setOnClick(ClickCallback cb);
   void setOnDrag(DragCallback cb);
   void setOnDrop(DropCallback cb);
 
-  void processEvent(const sf::Event& event);
+  void processEvent(const sf::Event &event);
 
- private:
-  bool m_dragging = false;                     ///< Indicates whether a drag operation is active.
-  std::optional<core::MousePos> m_drag_start;  ///< Starting position of an active drag.
+private:
+  bool m_dragging = false; ///< Indicates whether a drag operation is active.
+  std::optional<core::MousePos>
+      m_drag_start; ///< Starting position of an active drag.
+  std::chrono::steady_clock::time_point
+      m_drag_start_time; ///< Timestamp when the current drag started.
+  bool m_drag_triggered =
+      false; ///< Indicates whether on_drag has been invoked.
 
-  ClickCallback m_on_click = nullptr;  ///< Registered click callback.
-  DragCallback m_on_drag = nullptr;    ///< Registered drag callback.
-  DropCallback m_on_drop = nullptr;    ///< Registered drop callback.
+  ClickCallback m_on_click = nullptr; ///< Registered click callback.
+  DragCallback m_on_drag = nullptr;   ///< Registered drag callback.
+  DropCallback m_on_drop = nullptr;   ///< Registered drop callback.
 
-  [[nodiscard]] bool isClick(const core::MousePos& start, const core::MousePos& end,
+  [[nodiscard]] bool isClick(const core::MousePos &start,
+                             const core::MousePos &end,
                              int threshold = 2) const;
 };
 
-}  // namespace lilia::controller
+} // namespace lilia::controller

--- a/src/lilia/controller/input_manager.cpp
+++ b/src/lilia/controller/input_manager.cpp
@@ -6,56 +6,64 @@
 
 namespace lilia::controller {
 
-void InputManager::setOnClick(ClickCallback cb) {
-  m_on_click = std::move(cb);
-}
+void InputManager::setOnClick(ClickCallback cb) { m_on_click = std::move(cb); }
 
-void InputManager::setOnDrag(DragCallback cb) {
-  m_on_drag = std::move(cb);
-}
+void InputManager::setOnDrag(DragCallback cb) { m_on_drag = std::move(cb); }
 
-void InputManager::setOnDrop(DropCallback cb) {
-  m_on_drop = std::move(cb);
-}
+void InputManager::setOnDrop(DropCallback cb) { m_on_drop = std::move(cb); }
 
-void InputManager::processEvent(const sf::Event& event) {
+void InputManager::processEvent(const sf::Event &event) {
   switch (event.type) {
-    case sf::Event::MouseButtonPressed:
-      if (event.mouseButton.button == sf::Mouse::Left) {
-        m_drag_start = core::MousePos(event.mouseButton.x, event.mouseButton.y);
-        m_dragging = true;
-      }
-      break;
+  case sf::Event::MouseButtonPressed:
+    if (event.mouseButton.button == sf::Mouse::Left) {
+      m_drag_start = core::MousePos(event.mouseButton.x, event.mouseButton.y);
+      m_dragging = true;
+      m_drag_start_time = std::chrono::steady_clock::now();
+      m_drag_triggered = false;
+    }
+    break;
 
-    case sf::Event::MouseMoved:
-      if (m_dragging && m_drag_start) {
-        core::MousePos currentPos(event.mouseMove.x, event.mouseMove.y);
-        if (m_on_drag) m_on_drag(m_drag_start.value(), currentPos);
+  case sf::Event::MouseMoved:
+    if (m_dragging && m_drag_start) {
+      core::MousePos currentPos(event.mouseMove.x, event.mouseMove.y);
+      if (m_on_drag)
+        m_on_drag(m_drag_start.value(), currentPos);
+      m_drag_triggered = true;
+    }
+    break;
+  case sf::Event::MouseButtonReleased:
+    if (event.mouseButton.button == sf::Mouse::Left && m_dragging &&
+        m_drag_start) {
+      core::MousePos dropPos(event.mouseButton.x, event.mouseButton.y);
+      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - m_drag_start_time)
+                          .count();
+      if (duration < 100 && isClick(m_drag_start.value(), dropPos)) {
+        if (m_on_click)
+          m_on_click(dropPos);
+      } else {
+        if (!m_drag_triggered && m_on_drag)
+          m_on_drag(m_drag_start.value(), dropPos);
+        if (m_on_drop)
+          m_on_drop(m_drag_start.value(), dropPos);
       }
-      break;
-    case sf::Event::MouseButtonReleased:
-      if (event.mouseButton.button == sf::Mouse::Left && m_dragging && m_drag_start) {
-        core::MousePos dropPos(event.mouseButton.x, event.mouseButton.y);
-        if (isClick(m_drag_start.value(), dropPos)) {
-          if (m_on_click) m_on_click(dropPos);
-        } else {
-          if (m_on_drop) m_on_drop(m_drag_start.value(), dropPos);
-        }
-        m_drag_start.reset();
-        m_dragging = false;
-      }
-      break;
+      m_drag_start.reset();
+      m_dragging = false;
+      m_drag_triggered = false;
+    }
+    break;
 
-    default:
-      break;
+  default:
+    break;
   }
 }
 
-[[nodiscard]] bool InputManager::isClick(const core::MousePos& start, const core::MousePos& end,
+[[nodiscard]] bool InputManager::isClick(const core::MousePos &start,
+                                         const core::MousePos &end,
                                          int threshold) const {
   int dx = end.x - start.x;
   int dy = end.y - start.y;
   return (dx * dx + dy * dy) <= (threshold * threshold);
 }
 
-}  // namespace lilia::controller
+} // namespace lilia::controller


### PR DESCRIPTION
## Summary
- Detect long mouse presses and treat them as drags even without movement
- Differentiate click vs drag using a 100ms duration threshold

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68ae223c2cd883299d178e22e7158282