### PR TITLE
Add evaluation bar and decouple board from window size

### DIFF
--- a/include/lilia/view/eval_bar.hpp
+++ b/include/lilia/view/eval_bar.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <SFML/Graphics/RectangleShape.hpp>
+#include <SFML/Graphics/RenderWindow.hpp>
+
+#include "entity.hpp"
+#include "render_constants.hpp"
+
+namespace lilia::view {
+
+// Simple evaluation bar similar to chess.com. The bar displays the
+// evaluation from White's perspective: more white at the bottom means an
+// advantage for White.
+class EvalBar : public Entity {
+ public:
+  EvalBar();
+
+  void setEval(int evalCp);
+  void draw(sf::RenderWindow& window) override;
+
+ private:
+  int m_eval_cp{};
+  sf::RectangleShape m_background;
+  sf::RectangleShape m_white_part;
+};
+
+}  // namespace lilia::view

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -6,8 +6,11 @@
 
 #include "../constants.hpp"
 #include "../controller/mousepos.hpp"
+#include "../engine/eval.hpp"
+#include "../model/position.hpp"
 #include "animation/chess_animator.hpp"
 #include "board_view.hpp"
+#include "eval_bar.hpp"
 #include "highlight_manager.hpp"
 #include "piece_manager.hpp"
 #include "promotion_manager.hpp"
@@ -24,6 +27,8 @@ class GameView {
   void resetBoard();
 
   void update(float dt);
+
+  void updateEvaluation(model::Position& pos);
 
   void render();
 
@@ -78,6 +83,8 @@ class GameView {
   sf::Cursor m_cursor_default;
   sf::Cursor m_cursor_hand_open;
   sf::Cursor m_cursor_hand_closed;
+  EvalBar m_eval_bar;
+  engine::Evaluator m_evaluator;
 };
 
 }  // namespace lilia::view

--- a/include/lilia/view/render_constants.hpp
+++ b/include/lilia/view/render_constants.hpp
@@ -3,8 +3,17 @@
 
 namespace lilia::view::constant {
 constexpr unsigned int BOARD_SIZE = 8;
-constexpr unsigned int WINDOW_PX_SIZE = 800;
-constexpr unsigned int SQUARE_PX_SIZE = WINDOW_PX_SIZE / BOARD_SIZE;
+
+// Board and window dimensions are now decoupled so the board can keep a
+// fixed size while the window grows to host additional UI elements such as an
+// evaluation bar, clocks or player names.
+constexpr unsigned int BOARD_PX_SIZE = 800;
+constexpr unsigned int SIDEBAR_PX_SIZE = 200;  // space for evaluation bar & future UI
+constexpr unsigned int EVAL_BAR_PX_WIDTH = 80;
+constexpr unsigned int WINDOW_PX_WIDTH = BOARD_PX_SIZE + SIDEBAR_PX_SIZE;
+constexpr unsigned int WINDOW_PX_HEIGHT = BOARD_PX_SIZE;
+constexpr unsigned int BOARD_OFFSET_X = SIDEBAR_PX_SIZE;
+constexpr unsigned int SQUARE_PX_SIZE = BOARD_PX_SIZE / BOARD_SIZE;
 constexpr unsigned int ATTACK_DOT_PX_SIZE =
     static_cast<unsigned int>(static_cast<float>(SQUARE_PX_SIZE) * 0.45f + 0.5f);
 constexpr unsigned int CAPTURE_CIRCLE_PX_SIZE =

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -105,7 +105,8 @@ int App::run() {
   lilia::view::TextureTable::getInstance().preLoad();
 
   sf::RenderWindow window(
-      sf::VideoMode(lilia::view::constant::WINDOW_PX_SIZE, lilia::view::constant::WINDOW_PX_SIZE),
+      sf::VideoMode(lilia::view::constant::WINDOW_PX_WIDTH,
+                    lilia::view::constant::WINDOW_PX_HEIGHT),
       "Lilia", sf::Style::Titlebar | sf::Style::Close);
 
   {

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -190,6 +190,7 @@ void GameController::update(float dt) {
 
   m_game_view.update(dt);
   if (m_game_manager) m_game_manager->update(dt);
+  m_game_view.updateEvaluation(m_chess_game.getPositionRefForBot());
 }
 
 void GameController::highlightLastMove() {

--- a/src/lilia/view/board.cpp
+++ b/src/lilia/view/board.cpp
@@ -9,11 +9,11 @@ Board::Board(Entity::Position pos) : Entity(pos) {}
 void Board::init(const sf::Texture &textureWhite, const sf::Texture &textureBlack,
                  const sf::Texture &textureBoard) {
   setTexture(textureBoard);
-  setScale(constant::WINDOW_PX_SIZE, constant::WINDOW_PX_SIZE);
+  setScale(constant::BOARD_PX_SIZE, constant::BOARD_PX_SIZE);
 
   sf::Vector2f board_offset(
-      getPosition().x - constant::WINDOW_PX_SIZE / 2 + constant::SQUARE_PX_SIZE / 2,
-      getPosition().y - constant::WINDOW_PX_SIZE / 2 + constant::SQUARE_PX_SIZE / 2);
+      getPosition().x - constant::BOARD_PX_SIZE / 2 + constant::SQUARE_PX_SIZE / 2,
+      getPosition().y - constant::BOARD_PX_SIZE / 2 + constant::SQUARE_PX_SIZE / 2);
 
   for (int rank = 0; rank < constant::BOARD_SIZE; ++rank) {
     for (int file = 0; file < constant::BOARD_SIZE; ++file) {
@@ -49,8 +49,8 @@ void Board::draw(sf::RenderWindow &window) {
 void Board::setPosition(const Entity::Position &pos) {
   Entity::setPosition(pos);
   Entity::Position board_offset(
-      getPosition().x - constant::WINDOW_PX_SIZE / 2 + constant::SQUARE_PX_SIZE / 2,
-      getPosition().y - constant::WINDOW_PX_SIZE / 2 + constant::SQUARE_PX_SIZE / 2);
+      getPosition().x - constant::BOARD_PX_SIZE / 2 + constant::SQUARE_PX_SIZE / 2,
+      getPosition().y - constant::BOARD_PX_SIZE / 2 + constant::SQUARE_PX_SIZE / 2);
 
   for (int rank = 0; rank < constant::BOARD_SIZE; ++rank) {
     for (int file = 0; file < constant::BOARD_SIZE; ++file) {

--- a/src/lilia/view/board_view.cpp
+++ b/src/lilia/view/board_view.cpp
@@ -4,7 +4,9 @@
 
 namespace lilia::view {
 
-BoardView::BoardView() : m_board({constant::WINDOW_PX_SIZE / 2, constant::WINDOW_PX_SIZE / 2}) {}
+BoardView::BoardView()
+    : m_board({constant::BOARD_OFFSET_X + constant::BOARD_PX_SIZE / 2,
+               constant::BOARD_PX_SIZE / 2}) {}
 
 void BoardView::init() {
   m_board.init(TextureTable::getInstance().get(constant::STR_TEXTURE_WHITE),

--- a/src/lilia/view/eval_bar.cpp
+++ b/src/lilia/view/eval_bar.cpp
@@ -1,0 +1,39 @@
+#include "lilia/view/eval_bar.hpp"
+
+#include <algorithm>
+
+namespace lilia::view {
+
+EvalBar::EvalBar() {
+  m_background.setSize({static_cast<float>(constant::EVAL_BAR_PX_WIDTH),
+                        static_cast<float>(constant::BOARD_PX_SIZE)});
+  m_background.setFillColor(sf::Color(50, 50, 50));
+  m_background.setPosition(static_cast<float>(constant::BOARD_OFFSET_X -
+                                              constant::EVAL_BAR_PX_WIDTH),
+                           0.f);
+
+  m_white_part.setSize({static_cast<float>(constant::EVAL_BAR_PX_WIDTH),
+                        static_cast<float>(constant::BOARD_PX_SIZE) / 2.f});
+  m_white_part.setFillColor(sf::Color::White);
+  m_white_part.setPosition(
+      static_cast<float>(constant::BOARD_OFFSET_X - constant::EVAL_BAR_PX_WIDTH),
+      static_cast<float>(constant::BOARD_PX_SIZE) / 2.f);
+}
+
+void EvalBar::setEval(int evalCp) {
+  m_eval_cp = evalCp;
+  const int clamped = std::clamp(evalCp, -1000, 1000);
+  const float ratio = (clamped + 1000.f) / 2000.f;
+  const float whiteHeight = ratio * static_cast<float>(constant::BOARD_PX_SIZE);
+  m_white_part.setSize({static_cast<float>(constant::EVAL_BAR_PX_WIDTH), whiteHeight});
+  m_white_part.setPosition(
+      static_cast<float>(constant::BOARD_OFFSET_X - constant::EVAL_BAR_PX_WIDTH),
+      static_cast<float>(constant::BOARD_PX_SIZE) - whiteHeight);
+}
+
+void EvalBar::draw(sf::RenderWindow& window) {
+  window.draw(m_background);
+  window.draw(m_white_part);
+}
+
+}  // namespace lilia::view

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -12,7 +12,9 @@ GameView::GameView(sf::RenderWindow& window)
       m_board_view(),
       m_piece_manager(m_board_view),
       m_highlight_manager(m_board_view),
-      m_chess_animator(m_board_view, m_piece_manager) {
+      m_chess_animator(m_board_view, m_piece_manager),
+      m_eval_bar(),
+      m_evaluator() {
   m_cursor_default.loadFromSystem(sf::Cursor::Arrow);
 
   sf::Image openImg;
@@ -37,7 +39,14 @@ void GameView::update(float dt) {
   m_chess_animator.updateAnimations(dt);
 }
 
+void GameView::updateEvaluation(model::Position& pos) {
+  int eval = m_evaluator.evaluate(pos);
+  if (pos.getState().sideToMove == core::Color::Black) eval = -eval;
+  m_eval_bar.setEval(eval);
+}
+
 void GameView::render() {
+  m_eval_bar.draw(m_window);
   m_board_view.renderBoard(m_window);
   m_highlight_manager.renderSelect(m_window);
   m_chess_animator.renderHighlightLevel(m_window);
@@ -184,8 +193,10 @@ core::MousePos GameView::clampPosToWindowSize(core::MousePos mousePos) const noe
 }
 
 [[nodiscard]] core::Square GameView::mousePosToSquare(core::MousePos mousePos) const {
-  int file = clampPosToWindowSize(mousePos).x / constant::SQUARE_PX_SIZE;
-  int rankSFML = clampPosToWindowSize(mousePos).y / constant::SQUARE_PX_SIZE;
+  const auto clamped = clampPosToWindowSize(mousePos);
+  int file = (static_cast<int>(clamped.x) - static_cast<int>(constant::BOARD_OFFSET_X)) /
+             static_cast<int>(constant::SQUARE_PX_SIZE);
+  int rankSFML = clamped.y / constant::SQUARE_PX_SIZE;
 
   int rankFromWhite = 7 - rankSFML;
 


### PR DESCRIPTION
## Summary
- add EvalBar view component that renders engine evaluation like chess.com
- decouple board and window dimensions for future UI space
- integrate EvalBar into GameView and update via Evaluator
- refactor EvalBar to inherit from Entity for consistent rendering interface

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68b3090a8fc4832982446f1021ce26a8