### PR TITLE
Add coordinate labels to board edges

### DIFF
--- a/include/lilia/view/board.hpp
+++ b/include/lilia/view/board.hpp
@@ -29,6 +29,8 @@ class Board : public Entity {
 
  private:
   std::array<Entity, constant::BOARD_SIZE * constant::BOARD_SIZE> m_squares;
+  std::array<Entity, constant::BOARD_SIZE> m_file_labels;
+  std::array<Entity, constant::BOARD_SIZE> m_rank_labels;
 };
 
 }  // namespace lilia::view

--- a/src/lilia/view/board.cpp
+++ b/src/lilia/view/board.cpp
@@ -1,6 +1,9 @@
 #include "lilia/view/board.hpp"
 
 #include <SFML/Graphics/RenderWindow.hpp>
+#include <string>
+
+#include "lilia/view/texture_table.hpp"
 
 namespace lilia::view {
 
@@ -32,6 +35,34 @@ void Board::init(const sf::Texture &textureWhite, const sf::Texture &textureBlac
       m_squares[index].setOriginToCenter();
     }
   }
+
+  float offset = constant::SQUARE_PX_SIZE * 0.2f;
+  float bottom = board_offset.y + constant::BOARD_SIZE * constant::SQUARE_PX_SIZE -
+                 constant::SQUARE_PX_SIZE / 2 - offset;
+  float left = board_offset.x - constant::SQUARE_PX_SIZE / 2 + offset;
+
+  for (int file = 0; file < constant::BOARD_SIZE; ++file) {
+    std::string name = constant::ASSET_PIECES_FILE_PATH + "/file_" +
+                       std::string(1, static_cast<char>('a' + file)) + ".png";
+    m_file_labels[file].setTexture(TextureTable::getInstance().get(name));
+    auto size = m_file_labels[file].getOriginalSize();
+    float scale = (constant::SQUARE_PX_SIZE * 0.2f) / size.x;
+    m_file_labels[file].setScale(scale, scale);
+    float x = board_offset.x + file * constant::SQUARE_PX_SIZE;
+    m_file_labels[file].setPosition({x, bottom});
+  }
+
+  for (int rank = 0; rank < constant::BOARD_SIZE; ++rank) {
+    std::string name = constant::ASSET_PIECES_FILE_PATH + "/rank_" +
+                       std::to_string(rank + 1) + ".png";
+    m_rank_labels[rank].setTexture(TextureTable::getInstance().get(name));
+    auto size = m_rank_labels[rank].getOriginalSize();
+    float scale = (constant::SQUARE_PX_SIZE * 0.2f) / size.x;
+    m_rank_labels[rank].setScale(scale, scale);
+    float y = board_offset.y + (constant::BOARD_SIZE - 1 - rank) *
+                             constant::SQUARE_PX_SIZE;
+    m_rank_labels[rank].setPosition({left, y});
+  }
 }
 
 [[nodiscard]] Entity::Position Board::getPosOfSquare(core::Square sq) const {
@@ -43,6 +74,13 @@ void Board::draw(sf::RenderWindow &window) {
 
   for (auto &s : m_squares) {
     s.draw(window);
+  }
+
+  for (auto &l : m_file_labels) {
+    l.draw(window);
+  }
+  for (auto &l : m_rank_labels) {
+    l.draw(window);
   }
 }
 
@@ -61,6 +99,22 @@ void Board::setPosition(const Entity::Position &pos) {
 
       m_squares[index].setPosition({x, y});
     }
+  }
+
+  float offset = constant::SQUARE_PX_SIZE * 0.2f;
+  float bottom = board_offset.y + constant::BOARD_SIZE * constant::SQUARE_PX_SIZE -
+                 constant::SQUARE_PX_SIZE / 2 - offset;
+  float left = board_offset.x - constant::SQUARE_PX_SIZE / 2 + offset;
+
+  for (int file = 0; file < constant::BOARD_SIZE; ++file) {
+    float x = board_offset.x + file * constant::SQUARE_PX_SIZE;
+    m_file_labels[file].setPosition({x, bottom});
+  }
+
+  for (int rank = 0; rank < constant::BOARD_SIZE; ++rank) {
+    float y = board_offset.y + (constant::BOARD_SIZE - 1 - rank) *
+                             constant::SQUARE_PX_SIZE;
+    m_rank_labels[rank].setPosition({left, y});
   }
 }
 


### PR DESCRIPTION
## Summary
- Show file letters on board's bottom row and rank numbers along the left side
- Load and position label textures alongside squares, updating on board reposition

## Testing
- `rm -rf build && cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b335584600832983d1024079a341da