### PR TITLE
Add move list panel and reposition evaluation bar

### DIFF
--- a/include/lilia/view/board_view.hpp
+++ b/include/lilia/view/board_view.hpp
@@ -14,6 +14,9 @@ class BoardView {
   void renderBoard(sf::RenderWindow& window);
   [[nodiscard]] Entity::Position getSquareScreenPos(core::Square sq) const;
 
+  void setPosition(const Entity::Position& pos);
+  [[nodiscard]] Entity::Position getPosition() const;
+
  private:
   Board m_board;
 };

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -9,6 +9,7 @@
 #include "animation/chess_animator.hpp"
 #include "board_view.hpp"
 #include "eval_bar.hpp"
+#include "move_list_view.hpp"
 #include "highlight_manager.hpp"
 #include "piece_manager.hpp"
 #include "promotion_manager.hpp"
@@ -28,6 +29,10 @@ class GameView {
   void updateEval(int eval);
 
   void render();
+
+  void addMove(const std::string& move);
+  void onResize(unsigned int width, unsigned int height);
+  void scrollMoveList(float delta);
 
   [[nodiscard]] core::Square mousePosToSquare(core::MousePos mousePos) const;
   void setPieceToMouseScreenPos(core::Square pos, core::MousePos mousePos);
@@ -70,6 +75,7 @@ class GameView {
 
  private:
   core::MousePos clampPosToWindowSize(core::MousePos mousePos) const noexcept;
+  void layout(unsigned int width, unsigned int height);
 
   sf::RenderWindow& m_window;
   BoardView m_board_view;
@@ -81,6 +87,7 @@ class GameView {
   sf::Cursor m_cursor_hand_open;
   sf::Cursor m_cursor_hand_closed;
   EvalBar m_eval_bar;
+  MoveListView m_move_list;
 };
 
 }  // namespace lilia::view

--- a/include/lilia/view/move_list_view.hpp
+++ b/include/lilia/view/move_list_view.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <SFML/Graphics/Font.hpp>
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/Graphics/Text.hpp>
+#include <string>
+#include <vector>
+
+#include "render_constants.hpp"
+
+namespace lilia::view {
+
+class MoveListView {
+ public:
+  MoveListView();
+
+  void setPosition(const sf::Vector2f &pos);
+  void setSize(unsigned int width, unsigned int height);
+
+  void addMove(const std::string &uciMove);
+  void render(sf::RenderWindow &window) const;
+  void scroll(float delta);
+  void clear();
+
+ private:
+  sf::Font m_font;
+  std::vector<std::string> m_lines;
+  sf::Vector2f m_position{};  // Top-left position
+  unsigned int m_width{constant::MOVE_LIST_WIDTH};
+  unsigned int m_height{constant::WINDOW_PX_SIZE};
+  float m_scroll_offset{0.f};
+  std::size_t m_move_count{0};
+};
+
+}  // namespace lilia::view
+

--- a/include/lilia/view/render_constants.hpp
+++ b/include/lilia/view/render_constants.hpp
@@ -14,6 +14,20 @@ constexpr unsigned int EVAL_BAR_HEIGHT = WINDOW_PX_SIZE;
 constexpr unsigned int EVAL_BAR_WIDTH =
     static_cast<unsigned int>(static_cast<float>(WINDOW_PX_SIZE) * 0.1);
 
+// Breite des Bereichs für die Zugliste rechts neben dem Brett
+constexpr unsigned int MOVE_LIST_WIDTH =
+    static_cast<unsigned int>(static_cast<float>(WINDOW_PX_SIZE) * 0.25f);
+
+// Allgemeiner Abstand zwischen den Elementen (Eval-Bar, Brett, Zugliste)
+constexpr unsigned int SIDE_MARGIN =
+    static_cast<unsigned int>(static_cast<float>(SQUARE_PX_SIZE) * 0.5f);
+
+// Gesamtabmessungen des Fensters (Breite + Höhe)
+constexpr unsigned int WINDOW_TOTAL_WIDTH =
+    EVAL_BAR_WIDTH + SIDE_MARGIN + WINDOW_PX_SIZE + SIDE_MARGIN + MOVE_LIST_WIDTH +
+    SIDE_MARGIN;
+constexpr unsigned int WINDOW_TOTAL_HEIGHT = WINDOW_PX_SIZE + SIDE_MARGIN * 2;
+
 constexpr unsigned int HOVER_PX_SIZE = SQUARE_PX_SIZE;
 
 constexpr float ANIM_SNAP_SPEED = .005f;

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -105,8 +105,9 @@ int App::run() {
   lilia::view::TextureTable::getInstance().preLoad();
 
   sf::RenderWindow window(
-      sf::VideoMode(lilia::view::constant::WINDOW_PX_SIZE, lilia::view::constant::WINDOW_PX_SIZE),
-      "Lilia", sf::Style::Titlebar | sf::Style::Close);
+      sf::VideoMode(lilia::view::constant::WINDOW_TOTAL_WIDTH,
+                    lilia::view::constant::WINDOW_TOTAL_HEIGHT),
+      "Lilia", sf::Style::Titlebar | sf::Style::Resize | sf::Style::Close);
 
   {
     lilia::model::ChessGame chessGame;

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -13,6 +13,7 @@
 #include "lilia/model/chess_game.hpp"
 #include "lilia/model/move.hpp"
 #include "lilia/view/render_constants.hpp"
+#include "lilia/uci/uci_helper.hpp"
 
 namespace lilia::controller {
 
@@ -41,6 +42,7 @@ GameController::GameController(view::GameView& gView, model::ChessGame& game)
   m_game_manager->setOnMoveExecuted([this](const model::Move& mv, bool isPlayerMove, bool onClick) {
     this->movePieceAndClear(mv, isPlayerMove, onClick);
     this->m_chess_game.checkGameResult();
+    this->m_game_view.addMove(uci::move_to_uci(mv));
   });
 
   m_game_manager->setOnPromotionRequested([this](core::Square sq) {
@@ -90,6 +92,12 @@ void GameController::handleEvent(const sf::Event& event) {
     case sf::Event::MouseButtonReleased:
       if (event.mouseButton.button == sf::Mouse::Left)
         onMouseReleased(core::MousePos(event.mouseButton.x, event.mouseButton.y));
+      break;
+    case sf::Event::MouseWheelScrolled:
+      m_game_view.scrollMoveList(event.mouseWheelScroll.delta);
+      break;
+    case sf::Event::Resized:
+      m_game_view.onResize(event.size.width, event.size.height);
       break;
     default:
       break;

--- a/src/lilia/view/board_view.cpp
+++ b/src/lilia/view/board_view.cpp
@@ -19,4 +19,8 @@ void BoardView::renderBoard(sf::RenderWindow& window) {
   return m_board.getPosOfSquare(sq);
 }
 
+void BoardView::setPosition(const Entity::Position& pos) { m_board.setPosition(pos); }
+
+[[nodiscard]] Entity::Position BoardView::getPosition() const { return m_board.getPosition(); }
+
 }  // namespace lilia::view

--- a/src/lilia/view/move_list_view.cpp
+++ b/src/lilia/view/move_list_view.cpp
@@ -1,0 +1,59 @@
+#include "lilia/view/move_list_view.hpp"
+
+#include <algorithm>
+#include <SFML/Graphics/RectangleShape.hpp>
+
+namespace lilia::view {
+
+MoveListView::MoveListView() {
+  if (const sf::Font* def = sf::Font::getDefaultFont()) m_font = *def;
+}
+
+void MoveListView::setPosition(const sf::Vector2f& pos) { m_position = pos; }
+
+void MoveListView::setSize(unsigned int width, unsigned int height) {
+  m_width = width;
+  m_height = height;
+}
+
+void MoveListView::addMove(const std::string& uciMove) {
+  if (m_move_count % 2 == 0) {
+    unsigned int turn = static_cast<unsigned int>(m_move_count / 2 + 1);
+    m_lines.push_back(std::to_string(turn) + ". " + uciMove);
+  } else {
+    if (!m_lines.empty()) m_lines.back() += " " + uciMove;
+  }
+  ++m_move_count;
+}
+
+void MoveListView::render(sf::RenderWindow& window) const {
+  sf::RectangleShape bg;
+  bg.setPosition(m_position);
+  bg.setSize({static_cast<float>(m_width), static_cast<float>(m_height)});
+  bg.setFillColor(sf::Color(30, 30, 30));
+  window.draw(bg);
+
+  float y = m_position.y - m_scroll_offset + 5.f;
+  for (const auto& line : m_lines) {
+    sf::Text text(line, m_font, 16);
+    text.setFillColor(sf::Color::White);
+    text.setPosition(m_position.x + 5.f, y);
+    window.draw(text);
+    y += 20.f;
+  }
+}
+
+void MoveListView::scroll(float delta) {
+  m_scroll_offset -= delta * 20.f;
+  float maxOffset = std::max(0.f, static_cast<float>(m_lines.size()) * 20.f - m_height);
+  m_scroll_offset = std::clamp(m_scroll_offset, 0.f, maxOffset);
+}
+
+void MoveListView::clear() {
+  m_lines.clear();
+  m_move_count = 0;
+  m_scroll_offset = 0.f;
+}
+
+}  // namespace lilia::view
+


### PR DESCRIPTION
## Summary
- expand render constants with move list sizing and window dimensions
- add scrollable MoveListView and integrate into GameView
- reposition board and evaluation bar with responsive layout
- forward moves to view and handle resize and wheel events

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68b34afd47488329b9f7c24f5861e1eb