### PR TITLE
Enable configurable players and bot-vs-bot play

### DIFF
--- a/include/lilia/app/app.hpp
+++ b/include/lilia/app/app.hpp
@@ -21,11 +21,11 @@ class App {
 
   static std::string trim(const std::string& s);
   static std::string toLower(const std::string& s);
-  static bool parseYesNoDefaultTrue(const std::string& s);
+  static bool parseYesNo(const std::string& s, bool defaultVal);
 
   // parsed options
-  core::Color m_player_color = core::Color::White;
-  bool m_vs_bot = true;
+  bool m_white_is_bot = false;
+  bool m_black_is_bot = true;
   std::string m_start_fen;
   int m_thinkTimeMs = 10000;  // Bot think time in milliseconds
   int m_searchDepth = 10;     // Search depth for bot

--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -41,15 +41,15 @@ class GameController {
   // game_controller.hpp (in public:)
   /**
    * @brief Startet ein Spiel über den internen GameManager.
-   * @param playerColor Farbe des menschlichen Spielers (default: White).
    * @param fen Start-FEN (default: START_FEN).
-   * @param vsBot true = Gegner ist Bot, false = menschlicher Gegner.
+   * @param whiteIsBot true, falls der weiße Spieler ein Bot ist.
+   * @param blackIsBot true, falls der schwarze Spieler ein Bot ist.
    * @param thinkTimeMs Zeit in Millisekunden, die der Bot maximal denken darf.
    * @param depth Suchtiefe für den Bot.
    */
 
-  void startGame(core::Color playerColor, const std::string& fen = core::START_FEN,
-                 bool vsBot = true, int thinkTimeMs = 1000, int depth = 5);
+  void startGame(const std::string& fen = core::START_FEN, bool whiteIsBot = false,
+                 bool blackIsBot = true, int thinkTimeMs = 1000, int depth = 5);
 
  private:
   void onMouseMove(core::MousePos pos);
@@ -83,7 +83,6 @@ class GameController {
   InputManager m_input_manager;               ///< Handles raw input processing.
   view::sound::SoundManager m_sound_manager;  ///< Handles sfx and music
 
-  core::Color m_player_color = core::Color::White;
   core::Square m_promotion_square = core::NO_SQUARE;
 
   bool m_dragging = false;

--- a/include/lilia/controller/game_manager.hpp
+++ b/include/lilia/controller/game_manager.hpp
@@ -29,8 +29,9 @@ class GameManager {
   explicit GameManager(model::ChessGame& model);
   ~GameManager();
 
-  void startGame(core::Color playerColor, const std::string& fen = core::START_FEN,
-                 bool vsBot = true, int thinkTimeMs = 1000, int depth = 5);
+  void startGame(const std::string& fen = core::START_FEN,
+                 bool whiteIsBot = false, bool blackIsBot = true,
+                 int thinkTimeMs = 1000, int depth = 5);
   void stopGame();
 
   void update(float dt);
@@ -45,10 +46,11 @@ class GameManager {
 
   void setBotForColor(core::Color color, std::unique_ptr<IPlayer> bot);
 
+  [[nodiscard]] bool isHuman(core::Color color) const;
+  [[nodiscard]] bool isHumanTurn() const;
+
  private:
   model::ChessGame& m_game;
-  core::Color m_player_color = core::Color::White;
-
   // Players: nullptr bedeutet menschlicher Spieler
   std::unique_ptr<IPlayer> m_white_player;
   std::unique_ptr<IPlayer> m_black_player;

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -29,13 +29,14 @@ std::string App::toLower(const std::string& s) {
   return out;
 }
 
-bool App::parseYesNoDefaultTrue(const std::string& s) {
-  if (s.empty()) return true;
+bool App::parseYesNo(const std::string& s, bool defaultVal) {
+  if (s.empty()) return defaultVal;
   std::string normalized = toLower(trim(s));
-  if (normalized == "n" || normalized == "no" || normalized == "nah" || normalized == "0" ||
-      normalized == "false")
+  if (normalized == "y" || normalized == "yes" || normalized == "1" || normalized == "true")
+    return true;
+  if (normalized == "n" || normalized == "no" || normalized == "0" || normalized == "false")
     return false;
-  return true;
+  return defaultVal;
 }
 
 int App::parseIntInRange(const std::string& s, int defaultVal, int minVal, int maxVal) {
@@ -48,17 +49,15 @@ int App::parseIntInRange(const std::string& s, int defaultVal, int minVal, int m
 }
 
 void App::promptStartOptions() {
-  std::cout << "Player color (white / black) [Standard: white]: ";
-  std::string playerColorInput;
-  std::getline(std::cin, playerColorInput);
-  std::string normalizedColor = toLower(trim(playerColorInput));
-  m_player_color = (normalizedColor == "black" || normalizedColor == "b") ? core::Color::Black
-                                                                          : core::Color::White;
+  std::cout << "Is white a bot? (yes / no) [Standard: no]: ";
+  std::string whiteBotInput;
+  std::getline(std::cin, whiteBotInput);
+  m_white_is_bot = parseYesNo(whiteBotInput, false);
 
-  std::cout << "Enemy is bot? (yes / no) [Standard: yes]: ";
-  std::string botInput;
-  std::getline(std::cin, botInput);
-  m_vs_bot = parseYesNoDefaultTrue(botInput);
+  std::cout << "Is black a bot? (yes / no) [Standard: yes]: ";
+  std::string blackBotInput;
+  std::getline(std::cin, blackBotInput);
+  m_black_is_bot = parseYesNo(blackBotInput, true);
 
   std::cout << "Startposition as FEN [empty = Standard-Start]: ";
   std::string fenInput;
@@ -115,7 +114,8 @@ int App::run() {
     lilia::controller::GameController gameController(gameView, chessGame);
 
     // start the game using GameController wrapper that delegates to GameManager
-    gameController.startGame(m_player_color, m_start_fen, m_vs_bot, m_thinkTimeMs, m_searchDepth);
+    gameController.startGame(m_start_fen, m_white_is_bot, m_black_is_bot, m_thinkTimeMs,
+                            m_searchDepth);
 
     sf::Clock clock;
     while (window.isOpen()) {

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -57,12 +57,11 @@ GameController::GameController(view::GameView& gView, model::ChessGame& game)
 
 GameController::~GameController() = default;
 
-void GameController::startGame(core::Color playerColor, const std::string& fen, bool vsBot,
+void GameController::startGame(const std::string& fen, bool whiteIsBot, bool blackIsBot,
                                int think_time_ms, int depth) {
   m_sound_manager.playGameBegins();
   m_game_view.init(fen);
-  m_game_manager->startGame(playerColor, fen, vsBot, think_time_ms, depth);
-  m_player_color = playerColor;
+  m_game_manager->startGame(fen, whiteIsBot, blackIsBot, think_time_ms, depth);
 
   // UI-State
   m_mouse_down = false;
@@ -337,7 +336,7 @@ void GameController::snapAndReturn(core::Square sq, core::MousePos cur) {
 }
 
 void GameController::showAttacks(std::vector<core::Square> att) {
-  if (m_chess_game.getGameState().sideToMove != m_player_color) return;
+  if (!m_game_manager || !m_game_manager->isHumanTurn()) return;
   for (auto sq : att) {
     if (m_game_view.hasPieceOnSquare(sq))
       m_game_view.highlightCaptureSquare(sq);
@@ -361,8 +360,9 @@ void GameController::onClick(core::MousePos mousePos) {
   // Bereits etwas selektiert? -> erst Zug versuchen (hat Vorrang)
   if (m_selected_sq != core::NO_SQUARE) {
     const auto st = m_chess_game.getGameState();
-    const bool ownTurnAndPiece = (st.sideToMove == m_player_color) &&
-                                 (m_chess_game.getPiece(m_selected_sq).color == m_player_color);
+    const bool ownTurnAndPiece =
+        (st.sideToMove == m_chess_game.getPiece(m_selected_sq).color) &&
+        (!m_game_manager || m_game_manager->isHuman(st.sideToMove));
 
     if (ownTurnAndPiece && tryMove(m_selected_sq, sq)) {
       if (m_game_manager) {
@@ -441,8 +441,9 @@ void GameController::onDrop(core::MousePos start, core::MousePos end) {
   if (!accepted) {
     // Fehlversuch -> zurückschnappen
     if (m_chess_game.isKingInCheck(m_chess_game.getGameState().sideToMove) &&
-        m_chess_game.getGameState().sideToMove == m_player_color && from != to &&
-        m_game_view.hasPieceOnSquare(from) && m_chess_game.getPiece(from).color == m_player_color) {
+        m_game_manager && m_game_manager->isHuman(m_chess_game.getGameState().sideToMove) &&
+        from != to && m_game_view.hasPieceOnSquare(from) &&
+        m_chess_game.getPiece(from).color == m_chess_game.getGameState().sideToMove) {
       m_game_view.warningKingSquareAnim(
           m_chess_game.getKingSquare(m_chess_game.getGameState().sideToMove));
       m_sound_manager.playWarning();


### PR DESCRIPTION
## Summary
- Remove hardcoded single human player tracking and allow independent player types per color
- Add helpers to query whether a side is human and guard UI interactions accordingly
- Update app prompt to choose bot or human for both white and black

## Testing
- `cmake ..` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b3566be0f4832980bad10c82f98f99