### PR TITLE
Move eval bar score to advantaged side with contrasting colors

### DIFF
--- a/src/lilia/view/eval_bar.cpp
+++ b/src/lilia/view/eval_bar.cpp
@@ -27,7 +27,9 @@ EvalBar::EvalBar() : EvalBar::Entity() {
   m_font.loadFromFile(constant::STR_FILE_PATH_FONT);
   m_score_text.setFont(m_font);
   m_score_text.setCharacterSize(18);
-  m_score_text.setFillColor(sf::Color::White);
+  // Default evaluation is 0.0 (balanced), which appears on the white side,
+  // so draw the text in black for better visibility.
+  m_score_text.setFillColor(sf::Color::Black);
 }
 
 void EvalBar::setPosition(const Entity::Position& pos) {
@@ -58,9 +60,28 @@ void EvalBar::update(int eval) {
     ss.setf(std::ios::fixed); ss<< std::showpos << std::setprecision(1) << val;
     m_score_text.setString(ss.str());
   }
+  // Recompute origin after updating the text string
   auto b = m_score_text.getLocalBounds();
-  m_score_text.setOrigin(b.width/2.f, b.height/2.f);
-  m_score_text.setPosition(getPosition());
+  m_score_text.setOrigin(b.width / 2.f, b.height / 2.f);
+
+  // Place the score text on the side that currently has the advantage.
+  // If the evaluation favors White (>= 0), position the text at the bottom
+  // (white side) and draw it in black for contrast. Otherwise, position it
+  // at the top (black side) and draw it in white.
+  const float offset = 10.f;  // small margin from the edge of the bar
+  const float barHalfHeight =
+      static_cast<float>(constant::EVAL_BAR_HEIGHT) / 2.f;
+
+  float xPos = getPosition().x;
+  float yPos = getPosition().y;
+  if (m_display_eval >= 0.f) {
+    m_score_text.setFillColor(sf::Color::Black);
+    yPos += barHalfHeight - offset;
+  } else {
+    m_score_text.setFillColor(sf::Color::White);
+    yPos -= barHalfHeight - offset;
+  }
+  m_score_text.setPosition(xPos, yPos);
 }
 
 static float evalToWhitePct(float cp) {


### PR DESCRIPTION
## Summary
- Position evaluation text at the side with the current advantage (white or black)
- Adjust text color for readability: black on white side, white on black side
- Default score text is black for initial balanced position

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b3615cf164832980fccdb12a3511f3