### PR TITLE
Sharpen eval bar font

### DIFF
--- a/include/lilia/view/render_constants.hpp
+++ b/include/lilia/view/render_constants.hpp
@@ -5,14 +5,16 @@ namespace lilia::view::constant {
 constexpr unsigned int BOARD_SIZE = 8;
 constexpr unsigned int WINDOW_PX_SIZE = 800;
 constexpr unsigned int SQUARE_PX_SIZE = WINDOW_PX_SIZE / BOARD_SIZE;
-constexpr unsigned int ATTACK_DOT_PX_SIZE =
-    static_cast<unsigned int>(static_cast<float>(SQUARE_PX_SIZE) * 0.45f + 0.5f);
-constexpr unsigned int CAPTURE_CIRCLE_PX_SIZE =
-    static_cast<unsigned int>(static_cast<float>(SQUARE_PX_SIZE) * 1.02f + 0.5f);
+constexpr unsigned int ATTACK_DOT_PX_SIZE = static_cast<unsigned int>(
+    static_cast<float>(SQUARE_PX_SIZE) * 0.45f + 0.5f);
+constexpr unsigned int CAPTURE_CIRCLE_PX_SIZE = static_cast<unsigned int>(
+    static_cast<float>(SQUARE_PX_SIZE) * 1.02f + 0.5f);
 
 constexpr unsigned int EVAL_BAR_HEIGHT = WINDOW_PX_SIZE;
 constexpr unsigned int EVAL_BAR_WIDTH =
     static_cast<unsigned int>(static_cast<float>(WINDOW_PX_SIZE) * 0.05f);
+// Fontgröße für die Anzeige des Bewertungs-Textes
+constexpr unsigned int EVAL_BAR_FONT_SIZE = 14;
 
 // Breite des Bereichs für die Zugliste rechts neben dem Brett
 constexpr unsigned int MOVE_LIST_WIDTH =
@@ -23,9 +25,9 @@ constexpr unsigned int SIDE_MARGIN =
     static_cast<unsigned int>(static_cast<float>(SQUARE_PX_SIZE) * 0.5f);
 
 // Gesamtabmessungen des Fensters (Breite + Höhe)
-constexpr unsigned int WINDOW_TOTAL_WIDTH =
-    EVAL_BAR_WIDTH + SIDE_MARGIN + WINDOW_PX_SIZE + SIDE_MARGIN + MOVE_LIST_WIDTH +
-    SIDE_MARGIN;
+constexpr unsigned int WINDOW_TOTAL_WIDTH = EVAL_BAR_WIDTH + SIDE_MARGIN +
+                                            WINDOW_PX_SIZE + SIDE_MARGIN +
+                                            MOVE_LIST_WIDTH + SIDE_MARGIN;
 constexpr unsigned int WINDOW_TOTAL_HEIGHT = WINDOW_PX_SIZE + SIDE_MARGIN * 2;
 
 constexpr unsigned int HOVER_PX_SIZE = SQUARE_PX_SIZE;
@@ -49,8 +51,10 @@ const std::string STR_TEXTURE_HOVERHLIGHT = "hoverHighlight";
 const std::string STR_TEXTURE_WARNINGHLIGHT = "warningHighlight";
 const std::string STR_TEXTURE_HISTORY_OVERLAY = "historyOverlay";
 
-const std::string STR_FILE_PATH_HAND_OPEN = "assets/textures/cursor_hand_open.png";
-const std::string STR_FILE_PATH_HAND_CLOSED = "assets/textures/cursor_hand_closed.png";
+const std::string STR_FILE_PATH_HAND_OPEN =
+    "assets/textures/cursor_hand_open.png";
+const std::string STR_FILE_PATH_HAND_CLOSED =
+    "assets/textures/cursor_hand_closed.png";
 const std::string STR_FILE_PATH_FONT = "assets/font/OpenSans-Regular.ttf";
 
 const std::string ASSET_PIECES_FILE_PATH = "assets/textures";
@@ -67,4 +71,4 @@ const std::string SFX_PROMOTION_NAME = "promotion";
 const std::string SFX_GAME_BEGINS_NAME = "game_begins";
 const std::string SFX_GAME_ENDS_NAME = "game_ends";
 
-}  // namespace lilia::view::constant
+} // namespace lilia::view::constant

--- a/src/lilia/view/eval_bar.cpp
+++ b/src/lilia/view/eval_bar.cpp
@@ -15,30 +15,36 @@
 namespace lilia::view {
 
 EvalBar::EvalBar() : EvalBar::Entity() {
-  setTexture(TextureTable::getInstance().get(constant::STR_TEXTURE_TRANSPARENT));
+  setTexture(
+      TextureTable::getInstance().get(constant::STR_TEXTURE_TRANSPARENT));
   setScale(constant::EVAL_BAR_WIDTH, constant::EVAL_BAR_HEIGHT);
   setOriginToCenter();
-  m_black_background.setTexture(TextureTable::getInstance().get(constant::STR_TEXTURE_EVAL_BLACK));
-  m_white_fill_eval.setTexture(TextureTable::getInstance().get(constant::STR_TEXTURE_EVAL_WHITE));
-  m_black_background.setScale(constant::EVAL_BAR_WIDTH, constant::EVAL_BAR_HEIGHT);
-  m_white_fill_eval.setScale(constant::EVAL_BAR_WIDTH, constant::EVAL_BAR_HEIGHT);
+  m_black_background.setTexture(
+      TextureTable::getInstance().get(constant::STR_TEXTURE_EVAL_BLACK));
+  m_white_fill_eval.setTexture(
+      TextureTable::getInstance().get(constant::STR_TEXTURE_EVAL_WHITE));
+  m_black_background.setScale(constant::EVAL_BAR_WIDTH,
+                              constant::EVAL_BAR_HEIGHT);
+  m_white_fill_eval.setScale(constant::EVAL_BAR_WIDTH,
+                             constant::EVAL_BAR_HEIGHT);
   m_black_background.setOriginToCenter();
   m_white_fill_eval.setOriginToCenter();
   m_font.loadFromFile(constant::STR_FILE_PATH_FONT);
+  m_font.setSmooth(false);
   m_score_text.setFont(m_font);
-  m_score_text.setCharacterSize(12);
+  m_score_text.setCharacterSize(constant::EVAL_BAR_FONT_SIZE);
   // Default evaluation is 0.0 (balanced), which appears on the white side,
   // so draw the text in black for better visibility.
   m_score_text.setFillColor(sf::Color::Black);
 }
 
-void EvalBar::setPosition(const Entity::Position& pos) {
+void EvalBar::setPosition(const Entity::Position &pos) {
   Entity::setPosition(pos);
   m_black_background.setPosition(getPosition());
   m_white_fill_eval.setPosition(getPosition());
 }
 
-void EvalBar::render(sf::RenderWindow& window) {
+void EvalBar::render(sf::RenderWindow &window) {
   draw(window);
   m_black_background.draw(window);
   m_white_fill_eval.draw(window);
@@ -69,24 +75,27 @@ void EvalBar::update(int eval) {
   // If the evaluation favors White (>= 0), position the text at the bottom
   // (white side) and draw it in black for contrast. Otherwise, position it
   // at the top (black side) and draw it in white.
-  const float offset = 10.f;  // small margin from the edge of the bar
-  const float barHalfHeight = static_cast<float>(constant::EVAL_BAR_HEIGHT) / 2.f;
+  const float offset = 10.f; // small margin from the edge of the bar
+  const float barHalfHeight =
+      static_cast<float>(constant::EVAL_BAR_HEIGHT) / 2.f;
 
   float xPos = getPosition().x;
   float yPos = getPosition().y;
   if (m_display_eval >= 0.f) {
     m_score_text.setFillColor(sf::Color::Black);
-    yPos += barHalfHeight - offset * 1.5;  // *1.5 because of font origin position
+    yPos +=
+        barHalfHeight - offset * 1.5; // *1.5 because of font origin position
   } else {
     m_score_text.setFillColor(sf::Color::White);
     yPos -= barHalfHeight - offset;
   }
-  m_score_text.setPosition(xPos, yPos);
+  // Round to avoid blurry text caused by subpixel positioning
+  m_score_text.setPosition(std::round(xPos), std::round(yPos));
 }
 
 static float evalToWhitePct(float cp) {
-  constexpr float k = 1000.0f;             // langsamere Sättigung
-  return 0.5f + 0.5f * std::tanh(cp / k);  // 0.5 = ausgeglichen
+  constexpr float k = 1000.0f;            // langsamere Sättigung
+  return 0.5f + 0.5f * std::tanh(cp / k); // 0.5 = ausgeglichen
 }
 
 void EvalBar::scaleToEval(float e) {
@@ -98,19 +107,22 @@ void EvalBar::scaleToEval(float e) {
 
   // Sicherstellen, dass wir die Original-Texturgröße kennen
   auto whiteOrig = m_white_fill_eval.getOriginalSize();
-  if (whiteOrig.x <= 0.f || whiteOrig.y <= 0.f) return;
+  if (whiteOrig.x <= 0.f || whiteOrig.y <= 0.f)
+    return;
 
-  // Absolutgröße in Pixel => Skalierungsfaktoren = gewünschtePixel / OriginalPixel
+  // Absolutgröße in Pixel => Skalierungsfaktoren = gewünschtePixel /
+  // OriginalPixel
   const float sx = W / whiteOrig.x;
   const float sy = whitePx / whiteOrig.y;
   m_white_fill_eval.setScale(sx, sy);
 
   // Weiß unten „anheften“, damit 50% exakt Mitte ist (Origin = Center)
   const auto p = getPosition();
-  m_white_fill_eval.setPosition(Entity::Position{p.x, p.y + (H - whitePx) * 0.5f});
+  m_white_fill_eval.setPosition(
+      Entity::Position{p.x, p.y + (H - whitePx) * 0.5f});
 
-  // (Optional) Hintergrund sicher auf volle Größe bringen – einmalig im Ctor reicht,
-  // aber falls du es hier robust machen willst:
+  // (Optional) Hintergrund sicher auf volle Größe bringen – einmalig im Ctor
+  // reicht, aber falls du es hier robust machen willst:
   auto bgOrig = m_black_background.getOriginalSize();
   if (bgOrig.x > 0.f && bgOrig.y > 0.f) {
     m_black_background.setScale(W / bgOrig.x, H / bgOrig.y);
@@ -118,4 +130,4 @@ void EvalBar::scaleToEval(float e) {
   }
 }
 
-}  // namespace lilia::view
+} // namespace lilia::view


### PR DESCRIPTION
## Summary
- disable font smoothing and enlarge eval bar score text
- round score text position to avoid subpixel blurring
- add constant for eval bar font size

## Testing
- ⚠️ `cmake -S . -B build` *(fails: Could NOT find OpenGL)*
- ⚠️ `cmake --build build` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68b36d1db9dc83299e23009d5285960a