### PR TITLE
Fix board overlays, highlights and move sounds

### DIFF
--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -108,9 +108,14 @@ void GameController::handleEvent(const sf::Event& event) {
           m_game_view.selectMove(m_fen_index - 1);
           m_last_move_squares = m_move_history[m_fen_index - 1];
         }
+        m_game_view.clearAllHighlights();
         highlightLastMove();
         m_game_view.setHistoryOverlay(m_fen_index != m_fen_history.size() - 1);
-        m_sound_manager.playPlayerMove();
+        bool whiteMoved = (m_fen_index % 2 == 1);
+        if (whiteMoved)
+          m_sound_manager.playPlayerMove();
+        else
+          m_sound_manager.playEnemyMove();
       }
       return;
     } else if (event.key.code == sf::Keyboard::Right) {
@@ -119,9 +124,14 @@ void GameController::handleEvent(const sf::Event& event) {
         m_game_view.setBoardFen(m_fen_history[m_fen_index]);
         m_game_view.selectMove(m_fen_index - 1);
         m_last_move_squares = m_move_history[m_fen_index - 1];
+        m_game_view.clearAllHighlights();
         highlightLastMove();
         m_game_view.setHistoryOverlay(m_fen_index != m_fen_history.size() - 1);
-        m_sound_manager.playPlayerMove();
+        bool whiteMoved = (m_fen_index % 2 == 1);
+        if (whiteMoved)
+          m_sound_manager.playPlayerMove();
+        else
+          m_sound_manager.playEnemyMove();
       }
       return;
     }

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -181,7 +181,12 @@ void GameView::clearAllHighlights() {
   m_highlight_manager.clearAllHighlights();
 }
 
-void GameView::setHistoryOverlay(bool active) { m_show_history_overlay = active; }
+void GameView::setHistoryOverlay(bool active) {
+  m_show_history_overlay = active;
+  if (active) {
+    m_history_overlay.setPosition(m_board_view.getPosition());
+  }
+}
 
 bool GameView::isInPromotionSelection() {
   return m_promotion_manager.hasOptions();

--- a/src/lilia/view/highlight_manager.cpp
+++ b/src/lilia/view/highlight_manager.cpp
@@ -38,15 +38,18 @@ void HighlightManager::highlightSquare(core::Square pos) {
 }
 void HighlightManager::highlightAttackSquare(core::Square pos) {
   Entity newAttackHlight(TextureTable::getInstance().get(constant::STR_TEXTURE_ATTACKHLIGHT));
+  newAttackHlight.setScale(constant::ATTACK_DOT_PX_SIZE, constant::ATTACK_DOT_PX_SIZE);
   m_hl_attack_squares[pos] = std::move(newAttackHlight);
 }
 void HighlightManager::highlightCaptureSquare(core::Square pos) {
   Entity newCaptureHlight(TextureTable::getInstance().get(constant::STR_TEXTURE_CAPTUREHLIGHT));
+  newCaptureHlight.setScale(constant::CAPTURE_CIRCLE_PX_SIZE, constant::CAPTURE_CIRCLE_PX_SIZE);
   m_hl_attack_squares[pos] = std::move(newCaptureHlight);
 }
 
 void HighlightManager::highlightHoverSquare(core::Square pos) {
   Entity newHoverHlight(TextureTable::getInstance().get(constant::STR_TEXTURE_HOVERHLIGHT));
+  newHoverHlight.setScale(constant::HOVER_PX_SIZE, constant::HOVER_PX_SIZE);
   m_hl_hover_squares[pos] = std::move(newHoverHlight);
 }
 void HighlightManager::clearAllHighlights() {


### PR DESCRIPTION
## Summary
- Scale hover, attack and capture overlays to square size for proper board alignment
- Reset highlights and adjust sounds when traversing the move list
- Reposition history overlay whenever activated

## Testing
- `cmake -S . -B build` *(fails: Could NOT find VORBIS, FLAC etc? wait we installed; but final build still fails due to undefined X11 references. But in summary we show final command and failure)*
- `cmake --build build` *(fails: undefined reference to X libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68b36daf8e308329bd84e524f663e70b