### PR TITLE
Show player names with rating on board

### DIFF
--- a/include/lilia/view/cursor_manager.hpp
+++ b/include/lilia/view/cursor_manager.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/Window/Cursor.hpp>
+
+namespace lilia::view {
+
+class CursorManager {
+ public:
+  explicit CursorManager(sf::RenderWindow& window);
+
+  void setDefault();
+  void setHandOpen();
+  void setHandClosed();
+
+ private:
+  sf::RenderWindow& m_window;
+  sf::Cursor m_cursor_default;
+  sf::Cursor m_cursor_hand_open;
+  sf::Cursor m_cursor_hand_closed;
+};
+
+}  // namespace lilia::view
+

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -2,7 +2,6 @@
 
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/System/Vector2.hpp>
-#include <SFML/Window/Cursor.hpp>
 
 #include "../constants.hpp"
 #include "../controller/mousepos.hpp"
@@ -13,6 +12,8 @@
 #include "highlight_manager.hpp"
 #include "piece_manager.hpp"
 #include "promotion_manager.hpp"
+#include "cursor_manager.hpp"
+#include "player_info_view.hpp"
 
 namespace lilia::view {
 
@@ -34,6 +35,8 @@ class GameView {
   void selectMove(std::size_t moveIndex);
   void setBoardFen(const std::string& fen);
   void scrollMoveList(float delta);
+
+  void setPlayerNames(const std::string& whiteName, const std::string& blackName);
 
   [[nodiscard]] core::Square mousePosToSquare(core::MousePos mousePos) const;
   void setPieceToMouseScreenPos(core::Square pos, core::MousePos mousePos);
@@ -84,11 +87,10 @@ class GameView {
   HighlightManager m_highlight_manager;
   animation::ChessAnimator m_chess_animator;
   PromotionManager m_promotion_manager;
-  sf::Cursor m_cursor_default;
-  sf::Cursor m_cursor_hand_open;
-  sf::Cursor m_cursor_hand_closed;
   EvalBar m_eval_bar;
   MoveListView m_move_list;
+  CursorManager m_cursor_manager;
+  PlayerInfoView m_player_info;
 };
 
 }  // namespace lilia::view

--- a/include/lilia/view/player_info_view.hpp
+++ b/include/lilia/view/player_info_view.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <SFML/Graphics/Font.hpp>
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/Graphics/Text.hpp>
+#include <string>
+
+namespace lilia::view {
+
+class PlayerInfoView {
+ public:
+  PlayerInfoView();
+
+  void setNames(const std::string& white, const std::string& black);
+  void layout(float boardCenterX, float boardCenterY, float boardHalf);
+  void render(sf::RenderWindow& window);
+
+ private:
+  sf::Font m_font;
+  sf::Text m_white_text;
+  sf::Text m_black_text;
+};
+
+}  // namespace lilia::view
+

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -23,6 +23,7 @@ namespace {
 inline bool isValid(core::Square sq) {
   return sq != core::NO_SQUARE;
 }
+constexpr int kDefaultBotRating = 2400;
 }  // namespace
 
 GameController::GameController(view::GameView& gView, model::ChessGame& game)
@@ -67,6 +68,9 @@ void GameController::startGame(const std::string& fen, bool whiteIsBot, bool bla
                                int think_time_ms, int depth) {
   m_sound_manager.playGameBegins();
   m_game_view.init(fen);
+  std::string whiteName = whiteIsBot ? "Lilia (" + std::to_string(kDefaultBotRating) + ")" : "Challenger";
+  std::string blackName = blackIsBot ? "Lilia (" + std::to_string(kDefaultBotRating) + ")" : "Challenger";
+  m_game_view.setPlayerNames(whiteName, blackName);
   m_game_manager->startGame(fen, whiteIsBot, blackIsBot, think_time_ms, depth);
 
   m_fen_history.clear();

--- a/src/lilia/view/cursor_manager.cpp
+++ b/src/lilia/view/cursor_manager.cpp
@@ -1,0 +1,32 @@
+#include "lilia/view/cursor_manager.hpp"
+
+#include <SFML/Graphics/Image.hpp>
+
+#include "lilia/view/render_constants.hpp"
+
+namespace lilia::view {
+
+CursorManager::CursorManager(sf::RenderWindow& window) : m_window(window) {
+  m_cursor_default.loadFromSystem(sf::Cursor::Arrow);
+
+  sf::Image openImg;
+  if (openImg.loadFromFile(constant::STR_FILE_PATH_HAND_OPEN)) {
+    m_cursor_hand_open.loadFromPixels(openImg.getPixelsPtr(), openImg.getSize(),
+                                      {openImg.getSize().x / 2, openImg.getSize().y / 2});
+  }
+
+  sf::Image closedImg;
+  if (closedImg.loadFromFile(constant::STR_FILE_PATH_HAND_CLOSED)) {
+    m_cursor_hand_closed.loadFromPixels(closedImg.getPixelsPtr(), closedImg.getSize(),
+                                        {closedImg.getSize().x / 2, closedImg.getSize().y / 2});
+  }
+}
+
+void CursorManager::setDefault() { m_window.setMouseCursor(m_cursor_default); }
+
+void CursorManager::setHandOpen() { m_window.setMouseCursor(m_cursor_hand_open); }
+
+void CursorManager::setHandClosed() { m_window.setMouseCursor(m_cursor_hand_closed); }
+
+}  // namespace lilia::view
+

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -1,6 +1,5 @@
 #include "lilia/view/game_view.hpp"
 
-#include <SFML/Graphics/Image.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <algorithm>
 #include <iostream>
@@ -15,20 +14,10 @@ GameView::GameView(sf::RenderWindow& window)
       m_highlight_manager(m_board_view),
       m_chess_animator(m_board_view, m_piece_manager),
       m_eval_bar(),
-      m_move_list() {
-  m_cursor_default.loadFromSystem(sf::Cursor::Arrow);
-
-  sf::Image openImg;
-  if (openImg.loadFromFile(constant::STR_FILE_PATH_HAND_OPEN)) {
-    m_cursor_hand_open.loadFromPixels(openImg.getPixelsPtr(), openImg.getSize(),
-                                      {openImg.getSize().x / 2, openImg.getSize().y / 2});
-  }
-  sf::Image closedImg;
-  if (closedImg.loadFromFile(constant::STR_FILE_PATH_HAND_CLOSED)) {
-    m_cursor_hand_closed.loadFromPixels(closedImg.getPixelsPtr(), closedImg.getSize(),
-                                        {openImg.getSize().x / 2, openImg.getSize().y / 2});
-  }
-  m_window.setMouseCursor(m_cursor_default);
+      m_move_list(),
+      m_cursor_manager(window),
+      m_player_info() {
+  m_cursor_manager.setDefault();
   layout(m_window.getSize().x, m_window.getSize().y);
 }
 
@@ -55,6 +44,7 @@ void GameView::render() {
   m_highlight_manager.renderAttack(m_window);
   m_chess_animator.render(m_window);
   m_move_list.render(m_window);
+  m_player_info.render(m_window);
 }
 
 void GameView::addMove(const std::string& move) { m_move_list.addMove(move); }
@@ -68,6 +58,11 @@ void GameView::setBoardFen(const std::string& fen) {
 }
 
 void GameView::scrollMoveList(float delta) { m_move_list.scroll(delta); }
+
+void GameView::setPlayerNames(const std::string& whiteName, const std::string& blackName) {
+  m_player_info.setNames(whiteName, blackName);
+  layout(m_window.getSize().x, m_window.getSize().y);
+}
 
 void GameView::layout(unsigned int width, unsigned int height) {
   float vMargin =
@@ -98,6 +93,9 @@ void GameView::layout(unsigned int width, unsigned int height) {
                                                  constant::SIDE_MARGIN);
   m_move_list.setPosition({moveListX, vMargin});
   m_move_list.setSize(constant::MOVE_LIST_WIDTH, constant::WINDOW_PX_SIZE);
+
+  float boardHalf = static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
+  m_player_info.layout(boardCenterX, boardCenterY, boardHalf);
 }
 
 void GameView::resetBoard() {
@@ -262,15 +260,9 @@ void GameView::setPieceToMouseScreenPos(core::Square pos, core::MousePos mousePo
 void GameView::setPieceToSquareScreenPos(core::Square from, core::Square to) {
   m_piece_manager.setPieceToSquareScreenPos(from, to);
 }
-void GameView::setDefaultCursor() {
-  m_window.setMouseCursor(m_cursor_default);
-}
-void GameView::setHandOpenCursor() {
-  m_window.setMouseCursor(m_cursor_hand_open);
-}
-void GameView::setHandClosedCursor() {
-  m_window.setMouseCursor(m_cursor_hand_closed);
-}
+void GameView::setDefaultCursor() { m_cursor_manager.setDefault(); }
+void GameView::setHandOpenCursor() { m_cursor_manager.setHandOpen(); }
+void GameView::setHandClosedCursor() { m_cursor_manager.setHandClosed(); }
 
 sf::Vector2u GameView::getWindowSize() const {
   return m_window.getSize();

--- a/src/lilia/view/player_info_view.cpp
+++ b/src/lilia/view/player_info_view.cpp
@@ -1,0 +1,43 @@
+#include "lilia/view/player_info_view.hpp"
+
+#include "lilia/view/render_constants.hpp"
+
+namespace lilia::view {
+
+PlayerInfoView::PlayerInfoView() {
+  m_font.loadFromFile(constant::STR_FILE_PATH_FONT);
+  m_white_text.setFont(m_font);
+  m_black_text.setFont(m_font);
+  m_white_text.setCharacterSize(20);
+  m_black_text.setCharacterSize(20);
+  m_white_text.setFillColor(sf::Color::White);
+  m_black_text.setFillColor(sf::Color::White);
+}
+
+void PlayerInfoView::setNames(const std::string& white, const std::string& black) {
+  m_white_text.setString(white);
+  auto wb = m_white_text.getLocalBounds();
+  m_white_text.setOrigin(wb.width / 2.f, wb.height / 2.f);
+
+  m_black_text.setString(black);
+  auto bb = m_black_text.getLocalBounds();
+  m_black_text.setOrigin(bb.width / 2.f, bb.height / 2.f);
+}
+
+void PlayerInfoView::layout(float boardCenterX, float boardCenterY, float boardHalf) {
+  float offset = 20.f;
+  auto wb = m_white_text.getLocalBounds();
+  m_white_text.setPosition(
+      {boardCenterX, boardCenterY + boardHalf + offset + wb.height / 2.f});
+  auto bb = m_black_text.getLocalBounds();
+  m_black_text.setPosition(
+      {boardCenterX, boardCenterY - boardHalf - offset - bb.height / 2.f});
+}
+
+void PlayerInfoView::render(sf::RenderWindow& window) {
+  window.draw(m_white_text);
+  window.draw(m_black_text);
+}
+
+}  // namespace lilia::view
+


### PR DESCRIPTION
## Summary
- render player names under and above the board using the existing font
- label human players as **Challenger** and bots as **Lilia (rating)**
- refactor GameView to delegate name and cursor handling to dedicated PlayerInfoView and CursorManager facades

## Testing
- `cmake -S . -B build`
- `cmake --build build --target lilia_app -j2` *(fails: undefined reference to X11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b36c90f47c832987ccd8674e327ee1