### PR TITLE
Add bot-aware move list header and spacing

### DIFF
--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -18,7 +18,7 @@
 namespace lilia::view {
 
 class GameView {
- public:
+public:
   GameView(sf::RenderWindow &window);
   ~GameView() = default;
 
@@ -35,6 +35,7 @@ class GameView {
   void selectMove(std::size_t moveIndex);
   void setBoardFen(const std::string &fen);
   void scrollMoveList(float delta);
+  void setBotMode(bool anyBot);
 
   [[nodiscard]] std::size_t getMoveIndexAt(core::MousePos mousePos) const;
 
@@ -80,7 +81,7 @@ class GameView {
   void toggleBoardOrientation();
   [[nodiscard]] bool isOnFlipIcon(core::MousePos mousePos) const;
 
- private:
+private:
   core::MousePos clampPosToBoard(core::MousePos mousePos) const noexcept;
   void layout(unsigned int width, unsigned int height);
 
@@ -97,4 +98,4 @@ class GameView {
   MoveListView m_move_list;
 };
 
-}  // namespace lilia::view
+} // namespace lilia::view

--- a/include/lilia/view/move_list_view.hpp
+++ b/include/lilia/view/move_list_view.hpp
@@ -25,6 +25,8 @@ public:
   void scroll(float delta);
   void clear();
 
+  void setBotMode(bool anyBot);
+
   [[nodiscard]] std::size_t getMoveIndexAt(const Entity::Position &pos) const;
 
 private:
@@ -37,6 +39,7 @@ private:
   std::size_t m_move_count{0};
   std::size_t m_selected_move{static_cast<std::size_t>(-1)};
   std::vector<sf::FloatRect> m_move_bounds;
+  bool m_any_bot{false};
 };
 
 } // namespace lilia::view

--- a/include/lilia/view/rounded_rectangle_shape.hpp
+++ b/include/lilia/view/rounded_rectangle_shape.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <SFML/Graphics/Shape.hpp>
+
+namespace lilia::view {
+
+class RoundedRectangleShape : public sf::Shape {
+public:
+  explicit RoundedRectangleShape(const sf::Vector2f& size = {0.f, 0.f},
+                                 float radius = 0.f,
+                                 std::size_t cornerPointCount = 8);
+
+  void setSize(const sf::Vector2f& size);
+  const sf::Vector2f& getSize() const;
+
+  void setCornersRadius(float radius);
+  float getCornersRadius() const;
+
+  void setCornerPointCount(std::size_t count);
+  std::size_t getPointCount() const override;
+  sf::Vector2f getPoint(std::size_t index) const override;
+
+private:
+  sf::Vector2f m_size;
+  float m_radius;
+  std::size_t m_cornerPointCount;
+};
+
+}  // namespace lilia::view

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -20,18 +20,20 @@ namespace lilia::controller {
 
 namespace {
 // Kleiner Helfer: safe-compare für Squares
-inline bool isValid(core::Square sq) {
-  return sq != core::NO_SQUARE;
-}
-}  // namespace
+inline bool isValid(core::Square sq) { return sq != core::NO_SQUARE; }
+} // namespace
 
 GameController::GameController(view::GameView &gView, model::ChessGame &game)
     : m_game_view(gView), m_chess_game(game) {
-  m_input_manager.setOnClick([this](core::MousePos pos) { this->onClick(pos); });
+  m_input_manager.setOnClick(
+      [this](core::MousePos pos) { this->onClick(pos); });
   m_input_manager.setOnDrag(
-      [this](core::MousePos start, core::MousePos current) { this->onDrag(start, current); });
-  m_input_manager.setOnDrop(
-      [this](core::MousePos start, core::MousePos end) { this->onDrop(start, end); });
+      [this](core::MousePos start, core::MousePos current) {
+        this->onDrag(start, current);
+      });
+  m_input_manager.setOnDrop([this](core::MousePos start, core::MousePos end) {
+    this->onDrop(start, end);
+  });
 
   m_sound_manager.loadSounds();
 
@@ -40,21 +42,24 @@ GameController::GameController(view::GameView &gView, model::ChessGame &game)
   BotPlayer::setEvalCallback([this](int eval) { m_eval_cp.store(eval); });
 
   // Move-Callback – alles GUI/Animationen laufen über diese eine Stelle.
-  m_game_manager->setOnMoveExecuted([this](const model::Move &mv, bool isPlayerMove, bool onClick) {
-    this->movePieceAndClear(mv, isPlayerMove, onClick);
-    this->m_chess_game.checkGameResult();
-    this->m_game_view.addMove(move_to_uci(mv));
-    this->m_fen_history.push_back(this->m_chess_game.getFen());
-    this->m_move_history.emplace_back(mv.from, mv.to);
-    this->m_fen_index = this->m_fen_history.size() - 1;
-    this->m_game_view.setBoardFen(this->m_fen_history.back());
-    this->highlightLastMove();
-    this->m_game_view.selectMove(this->m_fen_index ? this->m_fen_index - 1
-                                                   : static_cast<std::size_t>(-1));
-  });
+  m_game_manager->setOnMoveExecuted(
+      [this](const model::Move &mv, bool isPlayerMove, bool onClick) {
+        this->movePieceAndClear(mv, isPlayerMove, onClick);
+        this->m_chess_game.checkGameResult();
+        this->m_game_view.addMove(move_to_uci(mv));
+        this->m_fen_history.push_back(this->m_chess_game.getFen());
+        this->m_move_history.emplace_back(mv.from, mv.to);
+        this->m_fen_index = this->m_fen_history.size() - 1;
+        this->m_game_view.setBoardFen(this->m_fen_history.back());
+        this->highlightLastMove();
+        this->m_game_view.selectMove(this->m_fen_index
+                                         ? this->m_fen_index - 1
+                                         : static_cast<std::size_t>(-1));
+      });
 
   m_game_manager->setOnPromotionRequested([this](core::Square sq) {
-    this->m_game_view.playPromotionSelectAnim(sq, m_chess_game.getGameState().sideToMove);
+    this->m_game_view.playPromotionSelectAnim(
+        sq, m_chess_game.getGameState().sideToMove);
   });
 
   m_game_manager->setOnGameEnd([this](core::GameResult res) {
@@ -65,10 +70,11 @@ GameController::GameController(view::GameView &gView, model::ChessGame &game)
 
 GameController::~GameController() = default;
 
-void GameController::startGame(const std::string &fen, bool whiteIsBot, bool blackIsBot,
-                               int think_time_ms, int depth) {
+void GameController::startGame(const std::string &fen, bool whiteIsBot,
+                               bool blackIsBot, int think_time_ms, int depth) {
   m_sound_manager.playGameBegins();
   m_game_view.init(fen);
+  m_game_view.setBotMode(whiteIsBot || blackIsBot);
   m_game_manager->startGame(fen, whiteIsBot, blackIsBot, think_time_ms, depth);
 
   m_fen_history.clear();
@@ -92,11 +98,13 @@ void GameController::startGame(const std::string &fen, bool whiteIsBot, bool bla
 }
 
 void GameController::handleEvent(const sf::Event &event) {
-  if (m_chess_game.getResult() != core::GameResult::ONGOING) return;
+  if (m_chess_game.getResult() != core::GameResult::ONGOING)
+    return;
 
-  if (event.type == sf::Event::MouseButtonPressed && event.mouseButton.button == sf::Mouse::Left) {
-    std::size_t idx =
-        m_game_view.getMoveIndexAt(core::MousePos(event.mouseButton.x, event.mouseButton.y));
+  if (event.type == sf::Event::MouseButtonPressed &&
+      event.mouseButton.button == sf::Mouse::Left) {
+    std::size_t idx = m_game_view.getMoveIndexAt(
+        core::MousePos(event.mouseButton.x, event.mouseButton.y));
     if (idx != static_cast<std::size_t>(-1)) {
       m_fen_index = idx + 1;
       m_game_view.setBoardFen(m_fen_history[m_fen_index]);
@@ -109,13 +117,15 @@ void GameController::handleEvent(const sf::Event &event) {
         m_sound_manager.playPlayerMove();
       else
         m_sound_manager.playEnemyMove();
+      m_game_view.setDefaultCursor();
       return;
     }
   }
 
   if (event.type == sf::Event::MouseWheelScrolled) {
     m_game_view.scrollMoveList(event.mouseWheelScroll.delta);
-    if (m_fen_index != m_fen_history.size() - 1) return;
+    if (m_fen_index != m_fen_history.size() - 1)
+      return;
   }
 
   if (event.type == sf::Event::KeyPressed) {
@@ -156,22 +166,23 @@ void GameController::handleEvent(const sf::Event &event) {
       return;
     }
   }
-  if (m_fen_index != m_fen_history.size() - 1) return;
+  if (m_fen_index != m_fen_history.size() - 1)
+    return;
 
   switch (event.type) {
-    case sf::Event::MouseMoved:
-      onMouseMove(core::MousePos(event.mouseMove.x, event.mouseMove.y));
-      break;
-    case sf::Event::MouseButtonPressed:
-      if (event.mouseButton.button == sf::Mouse::Left)
-        onMousePressed(core::MousePos(event.mouseButton.x, event.mouseButton.y));
-      break;
-    case sf::Event::MouseButtonReleased:
-      if (event.mouseButton.button == sf::Mouse::Left)
-        onMouseReleased(core::MousePos(event.mouseButton.x, event.mouseButton.y));
-      break;
-    default:
-      break;
+  case sf::Event::MouseMoved:
+    onMouseMove(core::MousePos(event.mouseMove.x, event.mouseMove.y));
+    break;
+  case sf::Event::MouseButtonPressed:
+    if (event.mouseButton.button == sf::Mouse::Left)
+      onMousePressed(core::MousePos(event.mouseButton.x, event.mouseButton.y));
+    break;
+  case sf::Event::MouseButtonReleased:
+    if (event.mouseButton.button == sf::Mouse::Left)
+      onMouseReleased(core::MousePos(event.mouseButton.x, event.mouseButton.y));
+    break;
+  default:
+    break;
   }
   m_input_manager.processEvent(event);
 }
@@ -185,6 +196,11 @@ void GameController::onMouseMove(core::MousePos pos) {
 
   if (m_mouse_down) {
     m_game_view.setHandClosedCursor();
+    return;
+  }
+
+  if (m_game_view.getMoveIndexAt(pos) != static_cast<std::size_t>(-1)) {
+    m_game_view.setHandOpenCursor();
     return;
   }
 
@@ -207,12 +223,14 @@ void GameController::onMousePressed(core::MousePos pos) {
 
   if (m_game_view.hasPieceOnSquare(sq)) {
     // Erst versuchen, ob ein Klick-Zug von der aktuellen Auswahl möglich ist.
-    if (!tryMove(m_selected_sq, sq)) m_game_view.setHandClosedCursor();
+    if (!tryMove(m_selected_sq, sq))
+      m_game_view.setHandClosedCursor();
   } else {
     m_game_view.setDefaultCursor();
   }
 
-  if (!m_game_view.hasPieceOnSquare(sq)) return;
+  if (!m_game_view.hasPieceOnSquare(sq))
+    return;
 
   // Preview-Logik: Wechsel der Auswahl neu highlighten
   if (m_selected_sq != core::NO_SQUARE && m_selected_sq != sq) {
@@ -262,21 +280,23 @@ void GameController::onMouseReleased(core::MousePos pos) {
   onMouseMove(pos);
 }
 
-void GameController::render() {
-  m_game_view.render();
-}
+void GameController::render() { m_game_view.render(); }
 
 void GameController::update(float dt) {
-  if (m_chess_game.getResult() != core::GameResult::ONGOING) return;
+  if (m_chess_game.getResult() != core::GameResult::ONGOING)
+    return;
 
   m_game_view.update(dt);
   m_game_view.updateEval(m_eval_cp.load());
-  if (m_game_manager) m_game_manager->update(dt);
+  if (m_game_manager)
+    m_game_manager->update(dt);
 }
 
 void GameController::highlightLastMove() {
-  if (isValid(m_last_move_squares.first)) m_game_view.highlightSquare(m_last_move_squares.first);
-  if (isValid(m_last_move_squares.second)) m_game_view.highlightSquare(m_last_move_squares.second);
+  if (isValid(m_last_move_squares.first))
+    m_game_view.highlightSquare(m_last_move_squares.first);
+  if (isValid(m_last_move_squares.second))
+    m_game_view.highlightSquare(m_last_move_squares.second);
 }
 
 void GameController::selectSquare(core::Square sq) {
@@ -296,12 +316,14 @@ void GameController::hoverSquare(core::Square sq) {
 }
 
 void GameController::dehoverSquare() {
-  if (isValid(m_hover_sq)) m_game_view.clearHighlightHoverSquare(m_hover_sq);
+  if (isValid(m_hover_sq))
+    m_game_view.clearHighlightHoverSquare(m_hover_sq);
   m_hover_sq = core::NO_SQUARE;
 }
 
 // --------- ZENTRALE Move-Callback-Behandlung (auch Engine-Züge) ----------
-void GameController::movePieceAndClear(const model::Move &move, bool isPlayerMove, bool onClick) {
+void GameController::movePieceAndClear(const model::Move &move,
+                                       bool isPlayerMove, bool onClick) {
   const core::Square from = move.from;
   const core::Square to = move.to;
 
@@ -314,7 +336,7 @@ void GameController::movePieceAndClear(const model::Move &move, bool isPlayerMov
     // Visuell zurück auf "from" klipsen und laufende Platzhalter/Drags beenden
     m_game_view.setPieceToSquareScreenPos(from, from);
     m_game_view.endAnimation(
-        from);  // beendet Base-Layer; (Highlight-Layer wird vom AnimMgr ersetzt)
+        from); // beendet Base-Layer; (Highlight-Layer wird vom AnimMgr ersetzt)
   }
 
   // 2) Auswahl-Konflikte entschärfen
@@ -328,8 +350,9 @@ void GameController::movePieceAndClear(const model::Move &move, bool isPlayerMov
   core::Square epVictimSq = core::NO_SQUARE;
   const core::Color moverColorBefore = ~m_chess_game.getGameState().sideToMove;
   if (move.isEnPassant) {
-    epVictimSq = (moverColorBefore == core::Color::White) ? static_cast<core::Square>(to - 8)
-                                                          : static_cast<core::Square>(to + 8);
+    epVictimSq = (moverColorBefore == core::Color::White)
+                     ? static_cast<core::Square>(to - 8)
+                     : static_cast<core::Square>(to + 8);
   }
 
   // 4) Los geht’s: Animationsauswahl je nach Eingabeart (Klick vs. Drag)
@@ -382,14 +405,16 @@ void GameController::snapAndReturn(core::Square sq, core::MousePos cur) {
 
 [[nodiscard]] bool GameController::tryMove(core::Square a, core::Square b) {
   for (auto att : getAttackSquares(a)) {
-    if (att == b) return true;
+    if (att == b)
+      return true;
   }
   return false;
 }
 
 [[nodiscard]] bool GameController::isPromotion(core::Square a, core::Square b) {
   for (const auto &m : m_chess_game.generateLegalMoves()) {
-    if (m.from == a && m.to == b && m.promotion != core::PieceType::None) return true;
+    if (m.from == a && m.to == b && m.promotion != core::PieceType::None)
+      return true;
   }
   return false;
 }
@@ -398,17 +423,19 @@ void GameController::snapAndReturn(core::Square sq, core::MousePos cur) {
   return m_game_view.isSameColorPiece(a, b);
 }
 
-[[nodiscard]] std::vector<core::Square> GameController::getAttackSquares(
-    core::Square pieceSQ) const {
+[[nodiscard]] std::vector<core::Square>
+GameController::getAttackSquares(core::Square pieceSQ) const {
   std::vector<core::Square> att;
   for (const auto &m : m_chess_game.generateLegalMoves()) {
-    if (m.from == pieceSQ) att.push_back(m.to);
+    if (m.from == pieceSQ)
+      att.push_back(m.to);
   }
   return att;
 }
 
 void GameController::showAttacks(std::vector<core::Square> att) {
-  if (!m_game_manager || !m_game_manager->isHumanTurn()) return;
+  if (!m_game_manager || !m_game_manager->isHumanTurn())
+    return;
   for (auto sq : att) {
     if (m_game_view.hasPieceOnSquare(sq))
       m_game_view.highlightCaptureSquare(sq);
@@ -426,9 +453,11 @@ void GameController::onClick(core::MousePos mousePos) {
 
   // Promotion-Auswahl?
   if (m_game_view.isInPromotionSelection()) {
-    const core::PieceType promoType = m_game_view.getSelectedPromotion(mousePos);
+    const core::PieceType promoType =
+        m_game_view.getSelectedPromotion(mousePos);
     m_game_view.removePromotionSelection();
-    if (m_game_manager) m_game_manager->completePendingPromotion(promoType);
+    if (m_game_manager)
+      m_game_manager->completePendingPromotion(promoType);
     deselectSquare();
     return;
   }
@@ -436,15 +465,16 @@ void GameController::onClick(core::MousePos mousePos) {
   // Bereits etwas selektiert? -> erst Zug versuchen (hat Vorrang)
   if (m_selected_sq != core::NO_SQUARE) {
     const auto st = m_chess_game.getGameState();
-    const bool ownTurnAndPiece = (st.sideToMove == m_chess_game.getPiece(m_selected_sq).color) &&
-                                 (!m_game_manager || m_game_manager->isHuman(st.sideToMove));
+    const bool ownTurnAndPiece =
+        (st.sideToMove == m_chess_game.getPiece(m_selected_sq).color) &&
+        (!m_game_manager || m_game_manager->isHuman(st.sideToMove));
 
     if (ownTurnAndPiece && tryMove(m_selected_sq, sq)) {
       if (m_game_manager) {
         (void)m_game_manager->requestUserMove(m_selected_sq, sq,
                                               /*onClick*/ true);
       }
-      return;  // NICHT umselektieren
+      return; // NICHT umselektieren
     }
 
     // Kein legaler Klick-Zug -> ggf. Auswahl ändern/entfernen
@@ -472,9 +502,12 @@ void GameController::onDrag(core::MousePos start, core::MousePos current) {
   const core::Square sqStart = m_game_view.mousePosToSquare(start);
   const core::Square sqMous = m_game_view.mousePosToSquare(current);
 
-  if (m_game_view.isInPromotionSelection()) return;
-  if (!m_game_view.hasPieceOnSquare(sqStart)) return;
-  if (!m_dragging) return;
+  if (m_game_view.isInPromotionSelection())
+    return;
+  if (!m_game_view.hasPieceOnSquare(sqStart))
+    return;
+  if (!m_dragging)
+    return;
 
   // Sicherstellen, dass die Startfigur selektiert ist
   if (m_selected_sq != sqStart) {
@@ -484,7 +517,8 @@ void GameController::onDrag(core::MousePos start, core::MousePos current) {
     showAttacks(getAttackSquares(sqStart));
   }
 
-  if (m_hover_sq != sqMous) dehoverSquare();
+  if (m_hover_sq != sqMous)
+    dehoverSquare();
   hoverSquare(sqMous);
 
   m_game_view.setPieceToMouseScreenPos(sqStart, current);
@@ -497,7 +531,8 @@ void GameController::onDrop(core::MousePos start, core::MousePos end) {
 
   dehoverSquare();
 
-  if (m_game_view.isInPromotionSelection()) return;
+  if (m_game_view.isInPromotionSelection())
+    return;
 
   if (!m_game_view.hasPieceOnSquare(from)) {
     deselectSquare();
@@ -516,10 +551,12 @@ void GameController::onDrop(core::MousePos start, core::MousePos end) {
 
   if (!accepted) {
     // Fehlversuch -> zurückschnappen
-    if (m_chess_game.isKingInCheck(m_chess_game.getGameState().sideToMove) && m_game_manager &&
-        m_game_manager->isHuman(m_chess_game.getGameState().sideToMove) && from != to &&
-        m_game_view.hasPieceOnSquare(from) &&
-        m_chess_game.getPiece(from).color == m_chess_game.getGameState().sideToMove) {
+    if (m_chess_game.isKingInCheck(m_chess_game.getGameState().sideToMove) &&
+        m_game_manager &&
+        m_game_manager->isHuman(m_chess_game.getGameState().sideToMove) &&
+        from != to && m_game_view.hasPieceOnSquare(from) &&
+        m_chess_game.getPiece(from).color ==
+            m_chess_game.getGameState().sideToMove) {
       m_game_view.warningKingSquareAnim(
           m_chess_game.getKingSquare(m_chess_game.getGameState().sideToMove));
       m_sound_manager.playWarning();
@@ -547,4 +584,4 @@ void GameController::onDrop(core::MousePos start, core::MousePos end) {
   m_prev_selected_before_preview = core::NO_SQUARE;
 }
 
-}  // namespace lilia::controller
+} // namespace lilia::controller

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -11,24 +11,23 @@
 namespace lilia::view {
 
 GameView::GameView(sf::RenderWindow &window)
-    : m_window(window),
-      m_board_view(),
-      m_piece_manager(m_board_view),
+    : m_window(window), m_board_view(), m_piece_manager(m_board_view),
       m_highlight_manager(m_board_view),
-      m_chess_animator(m_board_view, m_piece_manager),
-      m_eval_bar(),
+      m_chess_animator(m_board_view, m_piece_manager), m_eval_bar(),
       m_move_list() {
   m_cursor_default.loadFromSystem(sf::Cursor::Arrow);
 
   sf::Image openImg;
   if (openImg.loadFromFile(constant::STR_FILE_PATH_HAND_OPEN)) {
-    m_cursor_hand_open.loadFromPixels(openImg.getPixelsPtr(), openImg.getSize(),
-                                      {openImg.getSize().x / 2, openImg.getSize().y / 2});
+    m_cursor_hand_open.loadFromPixels(
+        openImg.getPixelsPtr(), openImg.getSize(),
+        {openImg.getSize().x / 2, openImg.getSize().y / 2});
   }
   sf::Image closedImg;
   if (closedImg.loadFromFile(constant::STR_FILE_PATH_HAND_CLOSED)) {
-    m_cursor_hand_closed.loadFromPixels(closedImg.getPixelsPtr(), closedImg.getSize(),
-                                        {openImg.getSize().x / 2, openImg.getSize().y / 2});
+    m_cursor_hand_closed.loadFromPixels(
+        closedImg.getPixelsPtr(), closedImg.getSize(),
+        {openImg.getSize().x / 2, openImg.getSize().y / 2});
   }
   m_window.setMouseCursor(m_cursor_default);
   layout(m_window.getSize().x, m_window.getSize().y);
@@ -39,13 +38,9 @@ void GameView::init(const std::string &fen) {
   m_piece_manager.initFromFen(fen);
 }
 
-void GameView::update(float dt) {
-  m_chess_animator.updateAnimations(dt);
-}
+void GameView::update(float dt) { m_chess_animator.updateAnimations(dt); }
 
-void GameView::updateEval(int eval) {
-  m_eval_bar.update(eval);
-}
+void GameView::updateEval(int eval) { m_eval_bar.update(eval); }
 
 void GameView::render() {
   m_eval_bar.render(m_window);
@@ -59,9 +54,7 @@ void GameView::render() {
   m_move_list.render(m_window);
 }
 
-void GameView::addMove(const std::string &move) {
-  m_move_list.addMove(move);
-}
+void GameView::addMove(const std::string &move) { m_move_list.addMove(move); }
 
 void GameView::selectMove(std::size_t moveIndex) {
   m_move_list.setCurrentMove(moveIndex);
@@ -73,34 +66,42 @@ void GameView::setBoardFen(const std::string &fen) {
   m_highlight_manager.clearAllHighlights();
 }
 
-void GameView::scrollMoveList(float delta) {
-  m_move_list.scroll(delta);
-}
+void GameView::scrollMoveList(float delta) { m_move_list.scroll(delta); }
+
+void GameView::setBotMode(bool anyBot) { m_move_list.setBotMode(anyBot); }
 
 std::size_t GameView::getMoveIndexAt(core::MousePos mousePos) const {
-  return m_move_list.getMoveIndexAt(
-      Entity::Position{static_cast<float>(mousePos.x), static_cast<float>(mousePos.y)});
+  return m_move_list.getMoveIndexAt(Entity::Position{
+      static_cast<float>(mousePos.x), static_cast<float>(mousePos.y)});
 }
 
 void GameView::layout(unsigned int width, unsigned int height) {
-  float vMargin = std::max(
-      0.f, (static_cast<float>(height) - static_cast<float>(constant::WINDOW_PX_SIZE)) / 2.f);
-  float hMargin = std::max(
-      0.f, (static_cast<float>(width) - static_cast<float>(constant::WINDOW_TOTAL_WIDTH)) / 2.f);
+  float vMargin = std::max(0.f, (static_cast<float>(height) -
+                                 static_cast<float>(constant::WINDOW_PX_SIZE)) /
+                                    2.f);
+  float hMargin =
+      std::max(0.f, (static_cast<float>(width) -
+                     static_cast<float>(constant::WINDOW_TOTAL_WIDTH)) /
+                        2.f);
 
-  float boardCenterX = hMargin +
-                       static_cast<float>(constant::EVAL_BAR_WIDTH + constant::SIDE_MARGIN) +
-                       static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
-  float boardCenterY = vMargin + static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
+  float boardCenterX =
+      hMargin +
+      static_cast<float>(constant::EVAL_BAR_WIDTH + constant::SIDE_MARGIN) +
+      static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
+  float boardCenterY =
+      vMargin + static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
 
   m_board_view.setPosition({boardCenterX, boardCenterY});
 
-  float evalCenterX =
-      hMargin + static_cast<float>(constant::EVAL_BAR_WIDTH + constant::SIDE_MARGIN) / 2.f;
+  float evalCenterX = hMargin + static_cast<float>(constant::EVAL_BAR_WIDTH +
+                                                   constant::SIDE_MARGIN) /
+                                    2.f;
   m_eval_bar.setPosition({evalCenterX, boardCenterY});
 
-  float moveListX = hMargin + static_cast<float>(constant::EVAL_BAR_WIDTH + constant::SIDE_MARGIN +
-                                                 constant::WINDOW_PX_SIZE + constant::SIDE_MARGIN);
+  float moveListX =
+      hMargin +
+      static_cast<float>(constant::EVAL_BAR_WIDTH + constant::SIDE_MARGIN +
+                         constant::WINDOW_PX_SIZE + constant::SIDE_MARGIN);
   m_move_list.setPosition({moveListX, vMargin});
   m_move_list.setSize(constant::MOVE_LIST_WIDTH, constant::WINDOW_PX_SIZE);
 }
@@ -115,20 +116,25 @@ void GameView::warningKingSquareAnim(core::Square ksq) {
   m_chess_animator.declareHighlightLevel(ksq);
 }
 
-void GameView::animationSnapAndReturn(core::Square sq, core::MousePos mousePos) {
+void GameView::animationSnapAndReturn(core::Square sq,
+                                      core::MousePos mousePos) {
   m_chess_animator.snapAndReturn(sq, mousePos);
 }
 
-void GameView::animationMovePiece(core::Square from, core::Square to, core::Square enPSquare,
+void GameView::animationMovePiece(core::Square from, core::Square to,
+                                  core::Square enPSquare,
                                   core::PieceType promotion) {
   m_chess_animator.movePiece(from, to, promotion);
-  if (enPSquare != core::NO_SQUARE) m_piece_manager.removePiece(enPSquare);
+  if (enPSquare != core::NO_SQUARE)
+    m_piece_manager.removePiece(enPSquare);
 }
 
-void GameView::animationDropPiece(core::Square from, core::Square to, core::Square enPSquare,
+void GameView::animationDropPiece(core::Square from, core::Square to,
+                                  core::Square enPSquare,
                                   core::PieceType promotion) {
   m_chess_animator.dropPiece(from, to, promotion);
-  if (enPSquare != core::NO_SQUARE) m_piece_manager.removePiece(enPSquare);
+  if (enPSquare != core::NO_SQUARE)
+    m_piece_manager.removePiece(enPSquare);
 }
 
 void GameView::playPiecePlaceHolderAnimation(core::Square sq) {
@@ -139,15 +145,14 @@ void GameView::playPromotionSelectAnim(core::Square promSq, core::Color c) {
   m_chess_animator.promotionSelect(promSq, m_promotion_manager, c);
 }
 
-void GameView::endAnimation(core::Square sq) {
-  m_chess_animator.end(sq);
-}
+void GameView::endAnimation(core::Square sq) { m_chess_animator.end(sq); }
 
 [[nodiscard]] bool GameView::hasPieceOnSquare(core::Square pos) const {
   return m_piece_manager.hasPieceOnSquare(pos);
 }
 
-[[nodiscard]] bool GameView::isSameColorPiece(core::Square sq1, core::Square sq2) const {
+[[nodiscard]] bool GameView::isSameColorPiece(core::Square sq1,
+                                              core::Square sq2) const {
   return m_piece_manager.isSameColor(sq1, sq2);
 }
 
@@ -181,7 +186,8 @@ bool GameView::isInPromotionSelection() {
 }
 
 core::PieceType GameView::getSelectedPromotion(core::MousePos mousePos) {
-  return m_promotion_manager.clickedOnType(static_cast<Entity::Position>(mousePos));
+  return m_promotion_manager.clickedOnType(
+      static_cast<Entity::Position>(mousePos));
 }
 
 void GameView::removePromotionSelection() {
@@ -191,22 +197,22 @@ void GameView::removePromotionSelection() {
 void GameView::showGameOver(core::GameResult res, core::Color sideToMove) {
   std::cout << "Game is Over!" << std::endl;
   switch (res) {
-    case core::GameResult::CHECKMATE:
-      std::cout << "CHECKMATE -> "
-                << (sideToMove == core::Color::White ? "Black won" : "White won");
-      break;
-    case core::GameResult::REPETITION:
-      std::cout << "REPITITION -> Draw!";
-      break;
-    case core::GameResult::MOVERULE:
-      std::cout << "MOVERULE-> Draw!";
-      break;
-    case core::GameResult::STALEMATE:
-      std::cout << "STALEMATE -> Draw!";
-      break;
+  case core::GameResult::CHECKMATE:
+    std::cout << "CHECKMATE -> "
+              << (sideToMove == core::Color::White ? "Black won" : "White won");
+    break;
+  case core::GameResult::REPETITION:
+    std::cout << "REPITITION -> Draw!";
+    break;
+  case core::GameResult::MOVERULE:
+    std::cout << "MOVERULE-> Draw!";
+    break;
+  case core::GameResult::STALEMATE:
+    std::cout << "STALEMATE -> Draw!";
+    break;
 
-    default:
-      std::cout << "result is not correct";
+  default:
+    std::cout << "result is not correct";
   }
   std::cout << std::endl;
 }
@@ -214,7 +220,8 @@ void GameView::showGameOver(core::GameResult res, core::Color sideToMove) {
 static inline int normalizeUnsignedToSigned(unsigned int u) {
   // Mappe 0..INT_MAX -> 0..INT_MAX, und (INT_MAX+1 .. UINT_MAX) -> negative
   // Werte
-  if (u <= static_cast<unsigned int>(std::numeric_limits<int>::max())) return static_cast<int>(u);
+  if (u <= static_cast<unsigned int>(std::numeric_limits<int>::max()))
+    return static_cast<int>(u);
   // -(UINT_MAX - u + 1)  (zweierkomplement-konsistent)
   return -static_cast<int>((std::numeric_limits<unsigned int>::max() - u) + 1u);
 }
@@ -223,7 +230,8 @@ constexpr int clampInt(int v, int lo, int hi) noexcept {
   return (v < lo) ? lo : (v > hi ? hi : v);
 }
 
-core::MousePos GameView::clampPosToBoard(core::MousePos mousePos) const noexcept {
+core::MousePos
+GameView::clampPosToBoard(core::MousePos mousePos) const noexcept {
   // 1) Unsigned -> Signed normalisieren (gegen negative Mauswerte außerhalb des
   // Fensters)
   const int sx = normalizeUnsignedToSigned(mousePos.x);
@@ -231,10 +239,10 @@ core::MousePos GameView::clampPosToBoard(core::MousePos mousePos) const noexcept
 
   // 2) Brettgrenzen bestimmen
   auto boardCenter = m_board_view.getPosition();
-  const int left =
-      static_cast<int>(boardCenter.x - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f);
-  const int top =
-      static_cast<int>(boardCenter.y - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f);
+  const int left = static_cast<int>(
+      boardCenter.x - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f);
+  const int top = static_cast<int>(
+      boardCenter.y - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f);
   const int right = left + static_cast<int>(constant::WINDOW_PX_SIZE) - 1;
   const int bottom = top + static_cast<int>(constant::WINDOW_PX_SIZE) - 1;
 
@@ -246,19 +254,25 @@ core::MousePos GameView::clampPosToBoard(core::MousePos mousePos) const noexcept
   return {static_cast<unsigned>(cx), static_cast<unsigned>(cy)};
 }
 
-[[nodiscard]] core::Square GameView::mousePosToSquare(core::MousePos mousePos) const {
+[[nodiscard]] core::Square
+GameView::mousePosToSquare(core::MousePos mousePos) const {
   auto boardCenter = m_board_view.getPosition();
-  float originX = boardCenter.x - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
-  float originY = boardCenter.y - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
+  float originX =
+      boardCenter.x - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
+  float originY =
+      boardCenter.y - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
   float right = originX + static_cast<float>(constant::WINDOW_PX_SIZE);
   float bottom = originY + static_cast<float>(constant::WINDOW_PX_SIZE);
 
-  if (mousePos.x < originX || mousePos.x >= right || mousePos.y < originY || mousePos.y >= bottom) {
+  if (mousePos.x < originX || mousePos.x >= right || mousePos.y < originY ||
+      mousePos.y >= bottom) {
     return core::NO_SQUARE;
   }
 
-  int fileSFML = static_cast<int>((mousePos.x - originX) / constant::SQUARE_PX_SIZE);
-  int rankSFML = static_cast<int>((mousePos.y - originY) / constant::SQUARE_PX_SIZE);
+  int fileSFML =
+      static_cast<int>((mousePos.x - originX) / constant::SQUARE_PX_SIZE);
+  int rankSFML =
+      static_cast<int>((mousePos.y - originY) / constant::SQUARE_PX_SIZE);
 
   int fileFromWhite;
   int rankFromWhite;
@@ -273,15 +287,14 @@ core::MousePos GameView::clampPosToBoard(core::MousePos mousePos) const noexcept
   return static_cast<core::Square>(rankFromWhite * 8 + fileFromWhite);
 }
 
-void GameView::setPieceToMouseScreenPos(core::Square pos, core::MousePos mousePos) {
+void GameView::setPieceToMouseScreenPos(core::Square pos,
+                                        core::MousePos mousePos) {
   m_piece_manager.setPieceToScreenPos(pos, clampPosToBoard(mousePos));
 }
 void GameView::setPieceToSquareScreenPos(core::Square from, core::Square to) {
   m_piece_manager.setPieceToSquareScreenPos(from, to);
 }
-void GameView::setDefaultCursor() {
-  m_window.setMouseCursor(m_cursor_default);
-}
+void GameView::setDefaultCursor() { m_window.setMouseCursor(m_cursor_default); }
 void GameView::setHandOpenCursor() {
   m_window.setMouseCursor(m_cursor_hand_open);
 }
@@ -289,20 +302,16 @@ void GameView::setHandClosedCursor() {
   m_window.setMouseCursor(m_cursor_hand_closed);
 }
 
-sf::Vector2u GameView::getWindowSize() const {
-  return m_window.getSize();
-}
+sf::Vector2u GameView::getWindowSize() const { return m_window.getSize(); }
 
 Entity::Position GameView::getPieceSize(core::Square pos) const {
   return m_piece_manager.getPieceSize(pos);
 }
 
-void GameView::toggleBoardOrientation() {
-  m_board_view.toggleFlipped();
-}
+void GameView::toggleBoardOrientation() { m_board_view.toggleFlipped(); }
 
 [[nodiscard]] bool GameView::isOnFlipIcon(core::MousePos mousePos) const {
   return m_board_view.isOnFlipIcon(mousePos);
 }
 
-}  // namespace lilia::view
+} // namespace lilia::view

--- a/src/lilia/view/move_list_view.cpp
+++ b/src/lilia/view/move_list_view.cpp
@@ -1,22 +1,30 @@
 #include "lilia/view/move_list_view.hpp"
 
+#include <SFML/Config.hpp>
 #include <SFML/Graphics/RectangleShape.hpp>
 #include <SFML/Graphics/View.hpp>
 #include <algorithm>
 
 #include "lilia/view/render_constants.hpp"
+#include "lilia/view/rounded_rectangle_shape.hpp"
 
 namespace lilia::view {
 
 namespace {
-constexpr float kPaddingX = 5.f;
-constexpr float kPaddingY = 5.f;
-constexpr float kLineHeight = 20.f;
-constexpr unsigned kFontSize = 16;
-}  // namespace
+constexpr float kPaddingX = 8.f;
+constexpr float kPaddingY = 8.f;
+constexpr float kLineHeight = 28.f;
+constexpr float kMoveSpacing = 10.f;
+constexpr float kListStartRatio = 0.3f;
+constexpr unsigned kMoveNumberFontSize = 14;
+constexpr unsigned kMoveFontSize = 18;
+constexpr unsigned kHeaderFontSize = 24;
+constexpr unsigned kSubHeaderFontSize = 20;
+} // namespace
 
 MoveListView::MoveListView() {
-  if (!m_font.loadFromFile(constant::STR_FILE_PATH_FONT)) { /* Fehlerbehandlung */
+  if (!m_font.loadFromFile(
+          constant::STR_FILE_PATH_FONT)) { /* Fehlerbehandlung */
   }
 }
 
@@ -29,33 +37,44 @@ void MoveListView::setSize(unsigned int width, unsigned int height) {
   m_height = height;
 }
 
+void MoveListView::setBotMode(bool anyBot) { m_any_bot = anyBot; }
+
 void MoveListView::addMove(const std::string &uciMove) {
   const std::size_t moveIndex = m_move_count;
   const std::size_t lineIndex = moveIndex / 2;
   const bool whiteMove = (moveIndex % 2) == 0;
+  const float contentTop = static_cast<float>(m_height) * kListStartRatio +
+                           static_cast<float>(kSubHeaderFontSize) +
+                           kMoveSpacing;
+  const float y = contentTop + static_cast<float>(lineIndex) * kLineHeight;
 
   if (whiteMove) {
     const unsigned turn = static_cast<unsigned>(lineIndex + 1);
-    std::string prefix = std::to_string(turn) + ". ";
-    m_lines.push_back(prefix + uciMove);
+    std::string numberStr = std::to_string(turn) + ".";
+    std::string lineStr = numberStr + " " + uciMove;
+    m_lines.push_back(lineStr);
 
-    sf::Text pre(prefix, m_font, kFontSize);
-    sf::Text moveTxt(uciMove, m_font, kFontSize);
-    float x = kPaddingX + pre.getLocalBounds().width;
-    float y = kPaddingY + static_cast<float>(lineIndex) * kLineHeight;
+    sf::Text numTxt(numberStr + " ", m_font, kMoveNumberFontSize);
+    sf::Text moveTxt(uciMove, m_font, kMoveFontSize);
+    float x = kPaddingX + numTxt.getLocalBounds().width + kMoveSpacing;
     float w = moveTxt.getLocalBounds().width;
     m_move_bounds.emplace_back(x, y, w, kLineHeight);
   } else {
     if (!m_lines.empty()) {
-      std::string prefix = m_lines.back();
-      sf::Text prefixTxt(prefix, m_font, kFontSize);
-      sf::Text space(" ", m_font, kFontSize);
-      float x = kPaddingX + prefixTxt.getLocalBounds().width + space.getLocalBounds().width;
-      float y = kPaddingY + static_cast<float>(lineIndex) * kLineHeight;
-      sf::Text moveTxt(uciMove, m_font, kFontSize);
+      std::string &line = m_lines.back();
+      // parse existing parts
+      std::size_t spacePos = line.find(' ');
+      std::string numberStr = line.substr(0, spacePos);     // "1."
+      std::string whiteMoveStr = line.substr(spacePos + 1); // "e4"
+      line += " " + uciMove;
+
+      sf::Text numTxt(numberStr + " ", m_font, kMoveNumberFontSize);
+      sf::Text whiteTxt(whiteMoveStr, m_font, kMoveFontSize);
+      sf::Text moveTxt(uciMove, m_font, kMoveFontSize);
+      float x = kPaddingX + numTxt.getLocalBounds().width + kMoveSpacing +
+                whiteTxt.getLocalBounds().width + kMoveSpacing;
       float w = moveTxt.getLocalBounds().width;
       m_move_bounds.emplace_back(x, y, w, kLineHeight);
-      m_lines.back() += " " + uciMove;
     }
   }
 
@@ -63,50 +82,105 @@ void MoveListView::addMove(const std::string &uciMove) {
   m_selected_move = m_move_count ? m_move_count - 1 : m_selected_move;
 
   const float content = static_cast<float>(m_lines.size()) * kLineHeight;
-  const float maxOff = std::max(0.f, content - static_cast<float>(m_height));
+  const float visibleHeight = static_cast<float>(m_height) - contentTop;
+  const float maxOff = std::max(0.f, content - visibleHeight);
   m_scroll_offset = std::clamp(maxOff, 0.f, maxOff);
 }
 
 void MoveListView::render(sf::RenderWindow &window) const {
-  sf::RectangleShape bg;
+  RoundedRectangleShape bg(
+      {static_cast<float>(m_width), static_cast<float>(m_height)}, 8.f, 10);
   bg.setPosition(m_position);
-  bg.setSize({static_cast<float>(m_width), static_cast<float>(m_height)});
   bg.setFillColor(sf::Color(38, 37, 34));
   window.draw(bg);
 
   const sf::View oldView = window.getView();
 
-  sf::View view(sf::FloatRect(0.f, 0.f, static_cast<float>(m_width), static_cast<float>(m_height)));
-  view.setViewport(
-      sf::FloatRect(m_position.x / static_cast<float>(window.getSize().x),
-                    m_position.y / static_cast<float>(window.getSize().y),
-                    static_cast<float>(m_width) / static_cast<float>(window.getSize().x),
-                    static_cast<float>(m_height) / static_cast<float>(window.getSize().y)));
+  sf::View view(sf::FloatRect(0.f, 0.f, static_cast<float>(m_width),
+                              static_cast<float>(m_height)));
+  view.setViewport(sf::FloatRect(
+      m_position.x / static_cast<float>(window.getSize().x),
+      m_position.y / static_cast<float>(window.getSize().y),
+      static_cast<float>(m_width) / static_cast<float>(window.getSize().x),
+      static_cast<float>(m_height) / static_cast<float>(window.getSize().y)));
   window.setView(view);
 
-  const float top = 0.f;
+  const float listTop = static_cast<float>(m_height) * kListStartRatio;
+  const float contentTop =
+      listTop + static_cast<float>(kSubHeaderFontSize) + kMoveSpacing;
+  const float top = contentTop;
   const float bottom = static_cast<float>(m_height);
 
-  if (m_selected_move != static_cast<std::size_t>(-1) && m_selected_move < m_move_bounds.size()) {
+  if (m_selected_move != static_cast<std::size_t>(-1) &&
+      m_selected_move < m_move_bounds.size()) {
     const auto &rect = m_move_bounds[m_selected_move];
     float y = rect.top - m_scroll_offset;
     if (y + rect.height >= top && y <= bottom) {
       sf::RectangleShape hl({rect.width, rect.height});
       hl.setPosition(rect.left, y);
-      hl.setFillColor(sf::Color(80, 80, 80));
+      hl.setFillColor(sf::Color(100, 100, 100));
       window.draw(hl);
     }
   }
 
+  // Überschriften
+  sf::Text header(m_any_bot ? "Play Bots" : "2 Player", m_font,
+                  kHeaderFontSize);
+  header.setStyle(sf::Text::Bold);
+  header.setFillColor(sf::Color::White);
+  header.setPosition(kPaddingX, kPaddingY);
+  window.draw(header);
+
+  sf::Text subHeader("Movelist", m_font, kSubHeaderFontSize);
+  subHeader.setStyle(sf::Text::Bold);
+  subHeader.setFillColor(sf::Color::White);
+  subHeader.setPosition(kPaddingX, listTop);
+  window.draw(subHeader);
+
   // Zeichne nur sichtbare Zeilen
   for (std::size_t i = 0; i < m_lines.size(); ++i) {
-    const float y = kPaddingY + (static_cast<float>(i) * kLineHeight) - m_scroll_offset;
-    if (y + kLineHeight < top || y > bottom) continue;
+    const float y =
+        contentTop + (static_cast<float>(i) * kLineHeight) - m_scroll_offset;
+    if (y + kLineHeight < top || y > bottom)
+      continue;
 
-    sf::Text text(m_lines[i], m_font, kFontSize);
-    text.setFillColor(sf::Color::White);
-    text.setPosition(kPaddingX, y);
-    window.draw(text);
+    std::string line = m_lines[i];
+    std::size_t spacePos = line.find(' ');
+    std::string numberStr = line.substr(0, spacePos);
+    std::string rest = line.substr(spacePos + 1);
+    std::size_t secondSpace = rest.find(' ');
+    std::string whiteMove = rest.substr(0, secondSpace);
+    std::string blackMove =
+        secondSpace == std::string::npos ? "" : rest.substr(secondSpace + 1);
+
+    sf::Text numTxt(numberStr + " ", m_font, kMoveNumberFontSize);
+    numTxt.setStyle(sf::Text::Regular);
+    numTxt.setFillColor(sf::Color(200, 200, 200));
+    numTxt.setPosition(kPaddingX, y);
+    window.draw(numTxt);
+
+    float x = kPaddingX + numTxt.getLocalBounds().width + kMoveSpacing;
+
+    sf::Text whiteTxt(whiteMove, m_font, kMoveFontSize);
+    whiteTxt.setStyle(sf::Text::Bold);
+    if (m_selected_move == i * 2)
+      whiteTxt.setFillColor(sf::Color(255, 255, 170));
+    else
+      whiteTxt.setFillColor(sf::Color::White);
+    whiteTxt.setPosition(x, y);
+    window.draw(whiteTxt);
+    x += whiteTxt.getLocalBounds().width + kMoveSpacing;
+
+    if (!blackMove.empty()) {
+      sf::Text blackTxt(blackMove, m_font, kMoveFontSize);
+      blackTxt.setStyle(sf::Text::Bold);
+      if (m_selected_move == i * 2 + 1)
+        blackTxt.setFillColor(sf::Color(255, 255, 170));
+      else
+        blackTxt.setFillColor(sf::Color::White);
+      blackTxt.setPosition(x, y);
+      window.draw(blackTxt);
+    }
   }
 
   window.setView(oldView);
@@ -115,7 +189,11 @@ void MoveListView::render(sf::RenderWindow &window) const {
 void MoveListView::scroll(float delta) {
   m_scroll_offset -= delta * kLineHeight;
   const float content = static_cast<float>(m_lines.size()) * kLineHeight;
-  const float maxOff = std::max(0.f, content - static_cast<float>(m_height));
+  const float contentTop = static_cast<float>(m_height) * kListStartRatio +
+                           static_cast<float>(kSubHeaderFontSize) +
+                           kMoveSpacing;
+  const float visibleHeight = static_cast<float>(m_height) - contentTop;
+  const float maxOff = std::max(0.f, content - visibleHeight);
   m_scroll_offset = std::clamp(m_scroll_offset, 0.f, maxOff);
 }
 
@@ -129,19 +207,25 @@ void MoveListView::clear() {
 
 void MoveListView::setCurrentMove(std::size_t moveIndex) {
   m_selected_move = moveIndex;
-  if (moveIndex == static_cast<std::size_t>(-1)) return;
+  if (moveIndex == static_cast<std::size_t>(-1))
+    return;
 
   const std::size_t lineIndex = moveIndex / 2;
   const float lineY = lineIndex * kLineHeight;
 
+  const float contentTop = static_cast<float>(m_height) * kListStartRatio +
+                           static_cast<float>(kSubHeaderFontSize) +
+                           kMoveSpacing;
+  const float visibleHeight = static_cast<float>(m_height) - contentTop;
+
   if (lineY < m_scroll_offset) {
     m_scroll_offset = lineY;
-  } else if (lineY + kLineHeight > m_scroll_offset + static_cast<float>(m_height)) {
-    m_scroll_offset = lineY + kLineHeight - static_cast<float>(m_height);
+  } else if (lineY + kLineHeight > m_scroll_offset + visibleHeight) {
+    m_scroll_offset = lineY + kLineHeight - visibleHeight;
   }
 
   const float content = static_cast<float>(m_lines.size()) * kLineHeight;
-  const float maxOff = std::max(0.f, content - static_cast<float>(m_height));
+  const float maxOff = std::max(0.f, content - visibleHeight);
   m_scroll_offset = std::clamp(m_scroll_offset, 0.f, maxOff);
 }
 
@@ -152,9 +236,10 @@ std::size_t MoveListView::getMoveIndexAt(const Entity::Position &pos) const {
     return static_cast<std::size_t>(-1);
 
   for (std::size_t i = 0; i < m_move_bounds.size(); ++i) {
-    if (m_move_bounds[i].contains(localX, localY)) return i;
+    if (m_move_bounds[i].contains(localX, localY))
+      return i;
   }
   return static_cast<std::size_t>(-1);
 }
 
-}  // namespace lilia::view
+} // namespace lilia::view

--- a/src/lilia/view/rounded_rectangle_shape.cpp
+++ b/src/lilia/view/rounded_rectangle_shape.cpp
@@ -1,0 +1,80 @@
+#include "lilia/view/rounded_rectangle_shape.hpp"
+
+#include <cmath>
+
+namespace lilia::view {
+
+RoundedRectangleShape::RoundedRectangleShape(const sf::Vector2f& size,
+                                             float radius,
+                                             std::size_t cornerPointCount)
+    : m_size(size), m_radius(radius), m_cornerPointCount(cornerPointCount) {
+  update();
+}
+
+void RoundedRectangleShape::setSize(const sf::Vector2f& size) {
+  m_size = size;
+  update();
+}
+
+const sf::Vector2f& RoundedRectangleShape::getSize() const { return m_size; }
+
+void RoundedRectangleShape::setCornersRadius(float radius) {
+  m_radius = radius;
+  update();
+}
+
+float RoundedRectangleShape::getCornersRadius() const { return m_radius; }
+
+void RoundedRectangleShape::setCornerPointCount(std::size_t count) {
+  m_cornerPointCount = count;
+  update();
+}
+
+std::size_t RoundedRectangleShape::getPointCount() const {
+  return m_cornerPointCount * 4;
+}
+
+sf::Vector2f RoundedRectangleShape::getPoint(std::size_t index) const {
+  if (m_radius == 0) {
+    switch (index) {
+      case 0:
+        return {0.f, 0.f};
+      case 1:
+        return {m_size.x, 0.f};
+      case 2:
+        return {m_size.x, m_size.y};
+      default:
+        return {0.f, m_size.y};
+    }
+  }
+
+  std::size_t corner = index / m_cornerPointCount;
+  float angle = (index % m_cornerPointCount) * 90.f /
+                static_cast<float>(m_cornerPointCount - 1);
+  float rad = angle * 3.141592654f / 180.f;
+
+  sf::Vector2f center;
+  switch (corner) {
+    case 0:
+      center = {m_size.x - m_radius, m_radius};
+      rad = -rad;
+      break;  // top-right
+    case 1:
+      center = {m_radius, m_radius};
+      rad = 180.f * 3.141592654f / 180.f - rad;
+      break;  // top-left
+    case 2:
+      center = {m_radius, m_size.y - m_radius};
+      rad = 180.f * 3.141592654f / 180.f + rad;
+      break;  // bottom-left
+    default:
+      center = {m_size.x - m_radius, m_size.y - m_radius};
+      rad = 2.f * 3.141592654f - rad;
+      break;  // bottom-right
+  }
+
+  return {center.x + std::cos(rad) * m_radius,
+          center.y + std::sin(rad) * m_radius};
+}
+
+}  // namespace lilia::view


### PR DESCRIPTION
## Summary
- Show "Play Bots" header when a bot participates or "2 Player" otherwise
- Reserve top 30% of move list for future bot icon and add "Movelist" subheading
- Expose bot mode setter in GameView and call from GameController

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b38e58c4508329bd9d00eda4ed8ec5