### PR TITLE
Add player info view and bot selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ file(GLOB_RECURSE UCI_FILES        ${PROJECT_SOURCE_DIR}/src/lilia/uci/*.cpp)
 file(GLOB_RECURSE CONTROLLER_FILES ${PROJECT_SOURCE_DIR}/src/lilia/controller/*.cpp)
 file(GLOB_RECURSE UI_FILES         ${PROJECT_SOURCE_DIR}/src/lilia/view/*.cpp)
 file(GLOB_RECURSE APP_FILES        ${PROJECT_SOURCE_DIR}/src/lilia/app/*.cpp)
+file(GLOB_RECURSE BOT_FILES        ${PROJECT_SOURCE_DIR}/src/lilia/bot/*.cpp)
 
 set(CORE_FILES
   ${MODEL_FILES}
@@ -61,6 +62,7 @@ add_executable(lilia_app
   ${UI_FILES}
   ${APP_FILES}
   ${CONTROLLER_FILES}
+  ${BOT_FILES}
 )
 
 target_compile_definitions(lilia_app PRIVATE LILIA_UI)

--- a/include/lilia/bot/bot_info.hpp
+++ b/include/lilia/bot/bot_info.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "lilia/player_info.hpp"
+
+namespace lilia {
+
+enum class BotType { Lilia };
+
+PlayerInfo getBotInfo(BotType type);
+
+} // namespace lilia
+

--- a/include/lilia/player_info.hpp
+++ b/include/lilia/player_info.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+namespace lilia {
+
+struct PlayerInfo {
+  std::string name;
+  int elo;
+  std::string iconPath;
+};
+
+} // namespace lilia
+

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -14,12 +14,14 @@
 #include "move_list_view.hpp"
 #include "piece_manager.hpp"
 #include "promotion_manager.hpp"
+#include "player_info_view.hpp"
 
 namespace lilia::view {
 
 class GameView {
 public:
-  GameView(sf::RenderWindow &window);
+  GameView(sf::RenderWindow &window, const PlayerInfo &topInfo,
+           const PlayerInfo &bottomInfo);
   ~GameView() = default;
 
   void init(const std::string &fen = core::START_FEN);
@@ -96,6 +98,8 @@ private:
   sf::Cursor m_cursor_hand_closed;
   EvalBar m_eval_bar;
   MoveListView m_move_list;
+  PlayerInfoView m_top_player;
+  PlayerInfoView m_bottom_player;
 };
 
 } // namespace lilia::view

--- a/include/lilia/view/player_info_view.hpp
+++ b/include/lilia/view/player_info_view.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <SFML/Graphics/RectangleShape.hpp>
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/Graphics/Text.hpp>
+
+#include "lilia/player_info.hpp"
+#include "entity.hpp"
+
+namespace lilia::view {
+
+class PlayerInfoView {
+ public:
+  PlayerInfoView();
+
+  void setInfo(const PlayerInfo& info);
+  void setPosition(const Entity::Position& pos);
+  void render(sf::RenderWindow& window) const;
+
+ private:
+  Entity m_icon;
+  sf::RectangleShape m_frame;
+  sf::Font m_font;
+  sf::Text m_text;
+  Entity::Position m_position{};
+};
+
+} // namespace lilia::view
+

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -11,6 +11,8 @@
 #include "lilia/model/chess_game.hpp"
 #include "lilia/view/game_view.hpp"
 #include "lilia/view/texture_table.hpp"
+#include "lilia/bot/bot_info.hpp"
+
 
 namespace lilia::app {
 
@@ -109,7 +111,19 @@ int App::run() {
 
   {
     lilia::model::ChessGame chessGame;
-    lilia::view::GameView gameView(window);
+    lilia::PlayerInfo topInfo;
+    if (m_black_is_bot)
+      topInfo = lilia::getBotInfo(lilia::BotType::Lilia);
+    else
+      topInfo = {"Player", 0, "assets/textures/1.png"};
+
+    lilia::PlayerInfo bottomInfo;
+    if (m_white_is_bot)
+      bottomInfo = lilia::getBotInfo(lilia::BotType::Lilia);
+    else
+      bottomInfo = {"Player", 0, "assets/textures/1.png"};
+
+    lilia::view::GameView gameView(window, topInfo, bottomInfo);
     lilia::controller::GameController gameController(gameView, chessGame);
 
     // start the game using GameController wrapper that delegates to GameManager

--- a/src/lilia/bot/bot_info.cpp
+++ b/src/lilia/bot/bot_info.cpp
@@ -1,0 +1,14 @@
+#include "lilia/bot/bot_info.hpp"
+
+namespace lilia {
+
+PlayerInfo getBotInfo(BotType type) {
+  switch (type) {
+    case BotType::Lilia:
+    default:
+      return {"Lilia", 2000, "assets/textures/5.png"};
+  }
+}
+
+} // namespace lilia
+

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -10,11 +10,12 @@
 
 namespace lilia::view {
 
-GameView::GameView(sf::RenderWindow &window)
+GameView::GameView(sf::RenderWindow &window, const PlayerInfo &topInfo,
+                   const PlayerInfo &bottomInfo)
     : m_window(window), m_board_view(), m_piece_manager(m_board_view),
       m_highlight_manager(m_board_view),
       m_chess_animator(m_board_view, m_piece_manager), m_eval_bar(),
-      m_move_list() {
+      m_move_list(), m_top_player(), m_bottom_player() {
   m_cursor_default.loadFromSystem(sf::Cursor::Arrow);
 
   sf::Image openImg;
@@ -30,6 +31,8 @@ GameView::GameView(sf::RenderWindow &window)
         {openImg.getSize().x / 2, openImg.getSize().y / 2});
   }
   m_window.setMouseCursor(m_cursor_default);
+  m_top_player.setInfo(topInfo);
+  m_bottom_player.setInfo(bottomInfo);
   layout(m_window.getSize().x, m_window.getSize().y);
 }
 
@@ -45,6 +48,8 @@ void GameView::updateEval(int eval) { m_eval_bar.update(eval); }
 void GameView::render() {
   m_eval_bar.render(m_window);
   m_board_view.renderBoard(m_window);
+  m_top_player.render(m_window);
+  m_bottom_player.render(m_window);
   m_highlight_manager.renderSelect(m_window);
   m_chess_animator.renderHighlightLevel(m_window);
   m_highlight_manager.renderHover(m_window);
@@ -104,6 +109,14 @@ void GameView::layout(unsigned int width, unsigned int height) {
                          constant::WINDOW_PX_SIZE + constant::SIDE_MARGIN);
   m_move_list.setPosition({moveListX, vMargin});
   m_move_list.setSize(constant::MOVE_LIST_WIDTH, constant::WINDOW_PX_SIZE);
+
+  float boardLeft = boardCenterX -
+                    static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
+  float boardTop = boardCenterY -
+                   static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
+  m_top_player.setPosition({boardLeft, boardTop - 50.f});
+  m_bottom_player.setPosition({
+      boardLeft, boardTop + static_cast<float>(constant::WINDOW_PX_SIZE) + 10.f});
 }
 
 void GameView::resetBoard() {

--- a/src/lilia/view/player_info_view.cpp
+++ b/src/lilia/view/player_info_view.cpp
@@ -1,0 +1,46 @@
+#include "lilia/view/player_info_view.hpp"
+
+#include "lilia/view/render_constants.hpp"
+#include "lilia/view/texture_table.hpp"
+
+namespace lilia::view {
+
+PlayerInfoView::PlayerInfoView() {
+  m_frame.setFillColor(sf::Color(60, 60, 60));
+  m_frame.setOutlineColor(sf::Color(120, 120, 120));
+  m_frame.setOutlineThickness(2.f);
+  if (m_font.loadFromFile(constant::STR_FILE_PATH_FONT)) {
+    m_text.setFont(m_font);
+    m_text.setCharacterSize(18);
+    m_text.setFillColor(sf::Color::White);
+  }
+}
+
+void PlayerInfoView::setInfo(const PlayerInfo& info) {
+  m_icon.setTexture(TextureTable::getInstance().get(info.iconPath));
+  auto size = m_icon.getOriginalSize();
+  if (size.x > 0) {
+    float scale = 32.f / static_cast<float>(size.x);
+    m_icon.setScale(scale, scale);
+  }
+  m_icon.setOriginToCenter();
+  m_text.setString(info.name + " (" + std::to_string(info.elo) + ")");
+  auto bounds = m_text.getLocalBounds();
+  m_frame.setSize({bounds.width + 48.f, 40.f});
+}
+
+void PlayerInfoView::setPosition(const Entity::Position& pos) {
+  m_position = pos;
+  m_frame.setPosition(pos);
+  m_icon.setPosition({pos.x + 20.f, pos.y + 20.f});
+  m_text.setPosition(pos.x + 40.f, pos.y + 8.f);
+}
+
+void PlayerInfoView::render(sf::RenderWindow& window) const {
+  window.draw(m_frame);
+  m_icon.draw(window);
+  window.draw(m_text);
+}
+
+} // namespace lilia::view
+


### PR DESCRIPTION
## Summary
- add PlayerInfo structure and BotType enum for future bots
- create PlayerInfoView to display player icon, name and Elo
- update GameView and app to show player info at top and bottom of the board

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b39f484960832994acc67ad43b1311