### PR TITLE
Improve move navigation visuals and sounds

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -68,10 +68,11 @@ class GameController {
   void hoverSquare(core::Square sq);
   void dehoverSquare();
 
-  void movePieceAndClear(const model::Move& move, bool isPlayerMove, bool onClick);
+  MoveSound movePieceAndClear(const model::Move& move, bool isPlayerMove, bool onClick);
 
   void snapAndReturn(core::Square sq, core::MousePos cur);
   void highlightLastMove();
+  void playStoredSound(std::size_t idx);
 
   [[nodiscard]] std::vector<core::Square> getAttackSquares(core::Square pieceSQ) const;
   void showAttacks(std::vector<core::Square> att);
@@ -99,13 +100,20 @@ class GameController {
   std::pair<core::Square, core::Square> m_last_move_squares = {
       core::NO_SQUARE, core::NO_SQUARE};  ///< Last executed move (from -> to).
 
+  enum class MoveSound { Player, Enemy, Capture, Check, Promotion, Castle };
+  struct MoveInfo {
+    core::Square from;
+    core::Square to;
+    MoveSound sound;
+  };
+
   // ---------------- New: GameManager ----------------
   std::unique_ptr<GameManager> m_game_manager;
   std::atomic<int> m_eval_cp{0};
 
   std::vector<std::string> m_fen_history;
   std::size_t m_fen_index{0};
-  std::vector<std::pair<core::Square, core::Square>> m_move_history;
+  std::vector<MoveInfo> m_move_history;
 };
 
 }  // namespace lilia::controller

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -54,6 +54,8 @@ public:
   void highlightAttackSquare(core::Square pos);
   void highlightCaptureSquare(core::Square pos);
   void highlightHoverSquare(core::Square pos);
+  void setLastMoveHighlight(core::Square from, core::Square to);
+  void clearLastMoveHighlights();
   void clearHighlightSquare(core::Square pos);
   void clearHighlightHoverSquare(core::Square pos);
   void clearAllHighlights();

--- a/include/lilia/view/highlight_manager.hpp
+++ b/include/lilia/view/highlight_manager.hpp
@@ -15,13 +15,17 @@ class HighlightManager {
   void highlightAttackSquare(core::Square pos);
   void highlightCaptureSquare(core::Square pos);
   void highlightHoverSquare(core::Square pos);
+  void highlightLastMoveSquare(core::Square pos);
+
   void clearAllHighlights();
+  void clearLastMoveHighlights();
   void clearHighlightSquare(core::Square pos);
   void clearHighlightHoverSquare(core::Square pos);
 
   void renderAttack(sf::RenderWindow& window);
   void renderHover(sf::RenderWindow& window);
   void renderSelect(sf::RenderWindow& window);
+  void renderLastMove(sf::RenderWindow& window);
 
  private:
   void renderEntitiesToBoard(std::unordered_map<core::Square, Entity>& map,
@@ -32,6 +36,7 @@ class HighlightManager {
   std::unordered_map<core::Square, Entity> m_hl_attack_squares;
   std::unordered_map<core::Square, Entity> m_hl_select_squares;
   std::unordered_map<core::Square, Entity> m_hl_hover_squares;
+  std::unordered_map<core::Square, Entity> m_hl_last_move_squares;
 };
 
 }  // namespace lilia::view

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -64,6 +64,7 @@ void GameView::render() {
   m_board_view.renderBoard(m_window);
   m_top_player.render(m_window);
   m_bottom_player.render(m_window);
+  m_highlight_manager.renderLastMove(m_window);
   m_highlight_manager.renderSelect(m_window);
   m_chess_animator.renderHighlightLevel(m_window);
   m_highlight_manager.renderHover(m_window);
@@ -83,6 +84,7 @@ void GameView::setBoardFen(const std::string &fen) {
   m_piece_manager.removeAll();
   m_piece_manager.initFromFen(fen);
   m_highlight_manager.clearAllHighlights();
+  m_highlight_manager.clearLastMoveHighlights();
 }
 
 void GameView::scrollMoveList(float delta) { m_move_list.scroll(delta); }
@@ -195,6 +197,16 @@ void GameView::highlightAttackSquare(core::Square pos) {
 }
 void GameView::highlightCaptureSquare(core::Square pos) {
   m_highlight_manager.highlightCaptureSquare(pos);
+}
+
+void GameView::setLastMoveHighlight(core::Square from, core::Square to) {
+  m_highlight_manager.clearLastMoveHighlights();
+  if (from != core::NO_SQUARE) m_highlight_manager.highlightLastMoveSquare(from);
+  if (to != core::NO_SQUARE) m_highlight_manager.highlightLastMoveSquare(to);
+}
+
+void GameView::clearLastMoveHighlights() {
+  m_highlight_manager.clearLastMoveHighlights();
 }
 
 void GameView::clearHighlightSquare(core::Square pos) {

--- a/src/lilia/view/highlight_manager.cpp
+++ b/src/lilia/view/highlight_manager.cpp
@@ -9,7 +9,8 @@ HighlightManager::HighlightManager(const BoardView& boardRef)
     : m_board_view_ref(boardRef),
       m_hl_attack_squares(),
       m_hl_select_squares(),
-      m_hl_hover_squares() {}
+      m_hl_hover_squares(),
+      m_hl_last_move_squares() {}
 
 void HighlightManager::renderEntitiesToBoard(std::unordered_map<core::Square, Entity>& map,
                                              sf::RenderWindow& window) {
@@ -30,6 +31,9 @@ void HighlightManager::renderHover(sf::RenderWindow& window) {
 void HighlightManager::renderSelect(sf::RenderWindow& window) {
   renderEntitiesToBoard(m_hl_select_squares, window);
 }
+void HighlightManager::renderLastMove(sf::RenderWindow& window) {
+  renderEntitiesToBoard(m_hl_last_move_squares, window);
+}
 
 void HighlightManager::highlightSquare(core::Square pos) {
   Entity newSelectHlight(TextureTable::getInstance().get(constant::STR_TEXTURE_SELECTHLIGHT));
@@ -49,11 +53,17 @@ void HighlightManager::highlightHoverSquare(core::Square pos) {
   Entity newHoverHlight(TextureTable::getInstance().get(constant::STR_TEXTURE_HOVERHLIGHT));
   m_hl_hover_squares[pos] = std::move(newHoverHlight);
 }
+void HighlightManager::highlightLastMoveSquare(core::Square pos) {
+  Entity newLastMove(TextureTable::getInstance().get(constant::STR_TEXTURE_SELECTHLIGHT));
+  newLastMove.setScale(constant::SQUARE_PX_SIZE, constant::SQUARE_PX_SIZE);
+  m_hl_last_move_squares[pos] = std::move(newLastMove);
+}
 void HighlightManager::clearAllHighlights() {
   m_hl_select_squares.clear();
   m_hl_attack_squares.clear();
   m_hl_hover_squares.clear();
 }
+void HighlightManager::clearLastMoveHighlights() { m_hl_last_move_squares.clear(); }
 void HighlightManager::clearHighlightSquare(core::Square pos) {
   m_hl_select_squares.erase(pos);
 }


### PR DESCRIPTION
## Summary
- Preserve last-move highlights across navigation and expose dedicated APIs
- Track a sound type for each move and replay the correct effect when browsing history
- Avoid reloading FEN after each move to prevent piece flicker

## Testing
- ⚠️ `cmake -S . -B build` *(missing OpenGL dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bb655ce48329a5eb8da47635e50e