### PR TITLE
feat: highlight board flip icon and settings area

### DIFF
--- a/include/lilia/view/board_view.hpp
+++ b/include/lilia/view/board_view.hpp
@@ -3,7 +3,6 @@
 #include <string>
 
 #include "board.hpp"
-#include "../controller/mousepos.hpp"
 
 namespace lilia::view {
 
@@ -17,14 +16,12 @@ class BoardView {
   void toggleFlipped();
   void setFlipped(bool flipped);
   [[nodiscard]] bool isFlipped() const;
-  [[nodiscard]] bool isOnFlipIcon(core::MousePos mousePos) const;
 
   void setPosition(const Entity::Position& pos);
   [[nodiscard]] Entity::Position getPosition() const;
 
  private:
   Board m_board;
-  Entity m_flip_icon;
   bool m_flipped{false};
 };
 

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -8,6 +8,7 @@
 #include "../controller/mousepos.hpp"
 #include "animation/chess_animator.hpp"
 #include "board_view.hpp"
+#include "settings_bar.hpp"
 #include "entity.hpp"
 #include "eval_bar.hpp"
 #include "highlight_manager.hpp"
@@ -93,6 +94,7 @@ private:
 
   sf::RenderWindow &m_window;
   BoardView m_board_view;
+  SettingsBar m_settings_bar;
   PieceManager m_piece_manager;
   HighlightManager m_highlight_manager;
   animation::ChessAnimator m_chess_animator;

--- a/include/lilia/view/settings_bar.hpp
+++ b/include/lilia/view/settings_bar.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <SFML/Graphics/RectangleShape.hpp>
+#include <SFML/Graphics/RenderWindow.hpp>
+
+#include "entity.hpp"
+#include "../controller/mousepos.hpp"
+
+namespace lilia::view {
+
+class SettingsBar {
+ public:
+  SettingsBar();
+
+  void init();
+  void setBoardPosition(const Entity::Position& boardCenter);
+  void render(sf::RenderWindow& window);
+  [[nodiscard]] bool isOnFlipIcon(core::MousePos mousePos) const;
+
+ private:
+  sf::RectangleShape m_background;
+  sf::RectangleShape m_icon_highlight;
+  Entity m_flip_icon;
+};
+
+}  // namespace lilia::view

--- a/src/lilia/view/board_view.cpp
+++ b/src/lilia/view/board_view.cpp
@@ -6,24 +6,17 @@ namespace lilia::view {
 
 BoardView::BoardView()
     : m_board({constant::WINDOW_PX_SIZE / 2, constant::WINDOW_PX_SIZE / 2}),
-      m_flip_icon(),
       m_flipped(false) {}
 
 void BoardView::init() {
   m_board.init(TextureTable::getInstance().get(constant::STR_TEXTURE_WHITE),
                TextureTable::getInstance().get(constant::STR_TEXTURE_BLACK),
                TextureTable::getInstance().get(constant::STR_TEXTURE_TRANSPARENT));
-  m_flip_icon.setTexture(TextureTable::getInstance().get(constant::STR_FILE_PATH_FLIP));
-  auto size = m_flip_icon.getOriginalSize();
-  float scale = (constant::SQUARE_PX_SIZE * 0.3f) / size.x;
-  m_flip_icon.setScale(scale, scale);
-  m_flip_icon.setOriginToCenter();
   setPosition(getPosition());
 }
 
 void BoardView::renderBoard(sf::RenderWindow& window) {
   m_board.draw(window);
-  m_flip_icon.draw(window);
 }
 [[nodiscard]] Entity::Position BoardView::getSquareScreenPos(core::Square sq) const {
   if (m_flipped) {
@@ -49,23 +42,10 @@ void BoardView::setFlipped(bool flipped) {
 
 void BoardView::setPosition(const Entity::Position& pos) {
   m_board.setPosition(pos);
-  float iconOffset = constant::SQUARE_PX_SIZE * 0.2f;
-  m_flip_icon.setPosition({pos.x + constant::WINDOW_PX_SIZE / 2.f + iconOffset,
-                           pos.y - constant::WINDOW_PX_SIZE / 2.f + 2.f - iconOffset});
 }
 
 [[nodiscard]] Entity::Position BoardView::getPosition() const {
   return m_board.getPosition();
-}
-
-[[nodiscard]] bool BoardView::isOnFlipIcon(core::MousePos mousePos) const {
-  auto pos = m_flip_icon.getPosition();
-  auto size = m_flip_icon.getCurrentSize();
-  float left = pos.x - size.x / 2.f;
-  float right = pos.x + size.x / 2.f;
-  float top = pos.y - size.y / 2.f;
-  float bottom = pos.y + size.y / 2.f;
-  return mousePos.x >= left && mousePos.x <= right && mousePos.y >= top && mousePos.y <= bottom;
 }
 
 }  // namespace lilia::view

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -15,6 +15,7 @@ namespace lilia::view {
 GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
     : m_window(window),
       m_board_view(),
+      m_settings_bar(),
       m_piece_manager(m_board_view),
       m_highlight_manager(m_board_view),
       m_chess_animator(m_board_view, m_piece_manager),
@@ -53,6 +54,7 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
     m_board_view.setFlipped(false);
   }
   m_bottom_player.setInfo(bottomInfo);
+  m_settings_bar.init();
 
   layout(m_window.getSize().x, m_window.getSize().y);
 }
@@ -73,6 +75,7 @@ void GameView::updateEval(int eval) {
 void GameView::render() {
   m_eval_bar.render(m_window);
   m_board_view.renderBoard(m_window);
+  m_settings_bar.render(m_window);
   m_top_player.render(m_window);
   m_bottom_player.render(m_window);
   m_highlight_manager.renderSelect(m_window);
@@ -124,6 +127,7 @@ void GameView::layout(unsigned int width, unsigned int height) {
   float boardCenterY = vMargin + static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
 
   m_board_view.setPosition({boardCenterX, boardCenterY});
+  m_settings_bar.setBoardPosition({boardCenterX, boardCenterY});
 
   float evalCenterX =
       hMargin + static_cast<float>(constant::EVAL_BAR_WIDTH + constant::SIDE_MARGIN) / 2.f;
@@ -354,7 +358,7 @@ void GameView::toggleBoardOrientation() {
 }
 
 [[nodiscard]] bool GameView::isOnFlipIcon(core::MousePos mousePos) const {
-  return m_board_view.isOnFlipIcon(mousePos);
+  return m_settings_bar.isOnFlipIcon(mousePos);
 }
 
 }  // namespace lilia::view

--- a/src/lilia/view/settings_bar.cpp
+++ b/src/lilia/view/settings_bar.cpp
@@ -1,0 +1,60 @@
+#include "lilia/view/settings_bar.hpp"
+
+#include "lilia/view/render_constants.hpp"
+#include "lilia/view/texture_table.hpp"
+
+namespace lilia::view {
+
+SettingsBar::SettingsBar() : m_background(), m_icon_highlight(), m_flip_icon() {}
+
+void SettingsBar::init() {
+  m_background.setSize({static_cast<float>(constant::SIDE_MARGIN),
+                        static_cast<float>(constant::WINDOW_PX_SIZE)});
+  m_background.setFillColor(sf::Color(255, 255, 255, 30));
+  m_background.setOutlineColor(sf::Color(200, 200, 200));
+  m_background.setOutlineThickness(2.f);
+
+  m_flip_icon.setTexture(TextureTable::getInstance().get(constant::STR_FILE_PATH_FLIP));
+  auto size = m_flip_icon.getOriginalSize();
+  float scale = (constant::SQUARE_PX_SIZE * 0.3f) / size.x;
+  m_flip_icon.setScale(scale, scale);
+  m_flip_icon.setOriginToCenter();
+
+  float highlightSize = constant::SQUARE_PX_SIZE * 0.5f;
+  m_icon_highlight.setSize({highlightSize, highlightSize});
+  m_icon_highlight.setOrigin({highlightSize / 2.f, highlightSize / 2.f});
+  m_icon_highlight.setFillColor(sf::Color(0, 0, 0, 0));
+  m_icon_highlight.setOutlineColor(sf::Color::White);
+  m_icon_highlight.setOutlineThickness(2.f);
+}
+
+void SettingsBar::setBoardPosition(const Entity::Position& boardCenter) {
+  float boardRight = boardCenter.x + constant::WINDOW_PX_SIZE / 2.f;
+  float boardTop = boardCenter.y - constant::WINDOW_PX_SIZE / 2.f;
+  m_background.setPosition({boardRight, boardTop});
+
+  float margin = constant::SQUARE_PX_SIZE * 0.2f;
+  float bgWidth = m_background.getSize().x;
+  auto iconSize = m_flip_icon.getCurrentSize();
+  m_flip_icon.setPosition({boardRight + bgWidth / 2.f,
+                           boardTop + margin + iconSize.y / 2.f});
+  m_icon_highlight.setPosition(m_flip_icon.getPosition());
+}
+
+void SettingsBar::render(sf::RenderWindow& window) {
+  window.draw(m_background);
+  window.draw(m_icon_highlight);
+  m_flip_icon.draw(window);
+}
+
+bool SettingsBar::isOnFlipIcon(core::MousePos mousePos) const {
+  auto pos = m_flip_icon.getPosition();
+  auto size = m_flip_icon.getCurrentSize();
+  float left = pos.x - size.x / 2.f;
+  float right = pos.x + size.x / 2.f;
+  float top = pos.y - size.y / 2.f;
+  float bottom = pos.y + size.y / 2.f;
+  return mousePos.x >= left && mousePos.x <= right && mousePos.y >= top && mousePos.y <= bottom;
+}
+
+}  // namespace lilia::view


### PR DESCRIPTION
## Summary
- add a `SettingsBar` that draws a highlighted column and outlines the board flip icon
- hook `SettingsBar` into `GameView` so the board flip icon starts a settings row
- remove flip icon handling from `BoardView`

## Testing
- `cmake ..` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ce783a248329b02d953e851b5194