### PR TITLE
Fix captured piece restoration during undo animations

### DIFF
--- a/include/lilia/view/animation/chess_animator.hpp
+++ b/include/lilia/view/animation/chess_animator.hpp
@@ -4,6 +4,7 @@
 #include "../board_view.hpp"
 #include "../piece_manager.hpp"
 #include "animation_manager.hpp"
+#include <functional>
 
 namespace lilia::view {
 class PromotionManager;
@@ -17,7 +18,8 @@ class ChessAnimator {
 
   void warningAnim(core::Square sq);
   void snapAndReturn(core::Square pieceSq, core::MousePos mousePos);
-  void movePiece(core::Square from, core::Square to, core::PieceType promotion);
+  void movePiece(core::Square from, core::Square to, core::PieceType promotion,
+                 std::function<void()> onComplete = {});
   void dropPiece(core::Square from, core::Square to, core::PieceType promotion);
   void piecePlaceHolder(core::Square sq);
   void promotionSelect(core::Square prPos, PromotionManager& prOptRef, core::Color c);

--- a/include/lilia/view/animation/move_animation.hpp
+++ b/include/lilia/view/animation/move_animation.hpp
@@ -3,6 +3,7 @@
 #include "../../chess_types.hpp"
 #include "../piece_manager.hpp"
 #include "i_animation.hpp"
+#include <functional>
 
 namespace lilia::view::animation {
 
@@ -10,7 +11,8 @@ class MoveAnim : public IAnimation {
  public:
   explicit MoveAnim(PieceManager& pieceMgrRef, Entity::Position s, Entity::Position e,
                     core::Square from = core::NO_SQUARE, core::Square to = core::NO_SQUARE,
-                    core::PieceType promotion = core::PieceType::None);
+                    core::PieceType promotion = core::PieceType::None,
+                    std::function<void()> onComplete = {});
   void update(float dt) override;
   void draw(sf::RenderWindow& window) override;
   [[nodiscard]] inline bool isFinished() const override;
@@ -25,6 +27,7 @@ class MoveAnim : public IAnimation {
   core::Square m_from;
   core::Square m_to;
   core::PieceType m_promotion;
+  std::function<void()> m_on_complete;
 };
 
 }  

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -16,6 +16,8 @@
 #include "promotion_manager.hpp"
 #include "player_info_view.hpp"
 
+#include <functional>
+
 namespace lilia::view {
 
 class GameView {
@@ -67,7 +69,8 @@ public:
   void animationSnapAndReturn(core::Square sq, core::MousePos mousePos);
   void animationMovePiece(core::Square from, core::Square to,
                           core::Square enPSquare = core::NO_SQUARE,
-                          core::PieceType promotion = core::PieceType::None);
+                          core::PieceType promotion = core::PieceType::None,
+                          std::function<void()> onComplete = {});
   void animationDropPiece(core::Square from, core::Square to,
                           core::Square enPSquare = core::NO_SQUARE,
                           core::PieceType promotion = core::PieceType::None);

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -123,7 +123,20 @@ void GameController::handleEvent(const sf::Event &event) {
                          ? static_cast<core::Square>(info.move.to - 8)
                          : static_cast<core::Square>(info.move.to + 8);
         }
-        m_game_view.animationMovePiece(info.move.to, info.move.from);
+        m_game_view.animationMovePiece(
+            info.move.to, info.move.from, core::NO_SQUARE, core::PieceType::None,
+            [this, info, epVictim]() {
+              if (info.move.isCapture) {
+                core::Square capSq =
+                    info.move.isEnPassant ? epVictim : info.move.to;
+                m_game_view.addPiece(info.capturedType, ~info.moverColor, capSq);
+              }
+              if (info.move.promotion != core::PieceType::None) {
+                m_game_view.removePiece(info.move.from);
+                m_game_view.addPiece(core::PieceType::Pawn, info.moverColor,
+                                     info.move.from);
+              }
+            });
         if (info.move.castle != model::CastleSide::None) {
           const core::Square rookFrom =
               m_chess_game.getRookSquareFromCastleside(info.move.castle, info.moverColor);
@@ -131,14 +144,6 @@ void GameController::handleEvent(const sf::Event &event) {
                                           ? static_cast<core::Square>(info.move.to - 1)
                                           : static_cast<core::Square>(info.move.to + 1);
           m_game_view.animationMovePiece(rookTo, rookFrom);
-        }
-        if (info.move.isCapture) {
-          core::Square capSq = info.move.isEnPassant ? epVictim : info.move.to;
-          m_game_view.addPiece(info.capturedType, ~info.moverColor, capSq);
-        }
-        if (info.move.promotion != core::PieceType::None) {
-          m_game_view.removePiece(info.move.from);
-          m_game_view.addPiece(core::PieceType::Pawn, info.moverColor, info.move.from);
         }
         --m_fen_index;
         m_game_view.selectMove(m_fen_index ? m_fen_index - 1 : static_cast<std::size_t>(-1));

--- a/src/lilia/view/animation/chess_animator.cpp
+++ b/src/lilia/view/animation/chess_animator.cpp
@@ -31,11 +31,13 @@ void ChessAnimator::snapAndReturn(core::Square pieceSq, core::MousePos mousePos)
       std::make_unique<SnapToSquareAnim>(m_piece_manager_ref, pieceSq, mouseToEntityPos(mousePos),
                                          m_board_view_ref.getSquareScreenPos(pieceSq)));
 }
-void ChessAnimator::movePiece(core::Square from, core::Square to, core::PieceType promotion) {
+void ChessAnimator::movePiece(core::Square from, core::Square to, core::PieceType promotion,
+                              std::function<void()> onComplete) {
   m_anim_manager.add(
       m_piece_manager_ref.getPieceID(from),
       std::make_unique<MoveAnim>(m_piece_manager_ref, m_board_view_ref.getSquareScreenPos(from),
-                                 m_board_view_ref.getSquareScreenPos(to), from, to, promotion));
+                                 m_board_view_ref.getSquareScreenPos(to), from, to, promotion,
+                                 std::move(onComplete)));
 }
 void ChessAnimator::dropPiece(core::Square from, core::Square to, core::PieceType promotion) {
   m_piece_manager_ref.movePiece(from, to, promotion);

--- a/src/lilia/view/animation/move_animation.cpp
+++ b/src/lilia/view/animation/move_animation.cpp
@@ -5,13 +5,15 @@
 namespace lilia::view::animation {
 
 MoveAnim::MoveAnim(PieceManager& pieceMgrRef, Entity::Position s, Entity::Position e,
-                   core::Square from, core::Square to, core::PieceType promotion)
+                   core::Square from, core::Square to, core::PieceType promotion,
+                   std::function<void()> onComplete)
     : m_piece_manager_ref(pieceMgrRef),
       m_start_pos(s),
       m_end_pos(e),
       m_from(from),
       m_to(to),
-      m_promotion(promotion) {}
+      m_promotion(promotion),
+      m_on_complete(std::move(onComplete)) {}
 
 void MoveAnim::update(float dt) {
   m_elapsed += dt;
@@ -22,6 +24,7 @@ void MoveAnim::update(float dt) {
   if (t >= 1.f) {
     m_finish = true;
     m_piece_manager_ref.movePiece(m_from, m_to, m_promotion);
+    if (m_on_complete) m_on_complete();
   }
 }
 

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -158,8 +158,9 @@ void GameView::animationSnapAndReturn(core::Square sq, core::MousePos mousePos) 
 }
 
 void GameView::animationMovePiece(core::Square from, core::Square to, core::Square enPSquare,
-                                  core::PieceType promotion) {
-  m_chess_animator.movePiece(from, to, promotion);
+                                  core::PieceType promotion,
+                                  std::function<void()> onComplete) {
+  m_chess_animator.movePiece(from, to, promotion, std::move(onComplete));
   if (enPSquare != core::NO_SQUARE) m_piece_manager.removePiece(enPSquare);
 }
 


### PR DESCRIPTION
## Summary
- ensure move animations can run a completion callback
- restore captured and promoted pieces after undo animation ends

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL -> installed; Could not find UDev -> installed; Could not find OpenAL -> installed; Could NOT find VORBIS -> installed; Could NOT find FLAC -> installed; Configuring done)*
- `cmake --build build --config Release` *(fails: undefined references to X11 symbols)*


------
https://chatgpt.com/codex/tasks/task_e_68b3ce4e61908329bdae212a0031718a