### PR TITLE
Implement resign and post-game options

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -59,6 +59,9 @@ public:
                  bool whiteIsBot = false, bool blackIsBot = true,
                  int thinkTimeMs = 1000, int depth = 5);
 
+  enum class NextAction { None, NewBot, Rematch };
+  [[nodiscard]] NextAction getNextAction() const;
+
 private:
   bool isHumanPiece(core::Square sq) const;
   bool hasCurrentLegalMove(core::Square from, core::Square to) const;
@@ -91,6 +94,10 @@ private:
   [[nodiscard]] bool isPromotion(core::Square a, core::Square b);
   [[nodiscard]] bool isSameColor(core::Square a, core::Square b);
   void showGameOver(core::GameResult res, core::Color sideToMove);
+
+  void stepBackward();
+  void stepForward();
+  void resign();
 
   // ---------------- Members ----------------
   view::GameView &m_game_view;    ///< Responsible for rendering.
@@ -126,6 +133,7 @@ private:
   std::vector<std::string> m_fen_history;
   std::size_t m_fen_index{0};
   std::vector<MoveView> m_move_history;
+  NextAction m_next_action{NextAction::None};
 };
 
 } // namespace lilia::controller

--- a/include/lilia/model/chess_game.hpp
+++ b/include/lilia/model/chess_game.hpp
@@ -30,6 +30,7 @@ class ChessGame {
   core::Square getRookSquareFromCastleside(CastleSide castleSide, core::Color side);
   core::Square getKingSquare(core::Color color);
   core::GameResult getResult();
+  void setResult(core::GameResult res);
   Position& getPositionRefForBot();
 
   std::string getFen() const;  ///< Aktuelle Stellung als FEN-String

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/Graphics/RectangleShape.hpp>
+#include <SFML/Graphics/Text.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <SFML/Window/Cursor.hpp>
 
@@ -35,12 +37,27 @@ public:
   void render();
 
   void addMove(const std::string &move);
+  void addResult(const std::string &result);
   void selectMove(std::size_t moveIndex);
   void setBoardFen(const std::string &fen);
   void scrollMoveList(float delta);
   void setBotMode(bool anyBot);
 
   [[nodiscard]] std::size_t getMoveIndexAt(core::MousePos mousePos) const;
+  [[nodiscard]] MoveListView::Option getOptionAt(core::MousePos mousePos) const;
+  void setGameOver(bool over);
+
+  void showResignPopup();
+  void hideResignPopup();
+  [[nodiscard]] bool isResignPopupOpen() const;
+  [[nodiscard]] bool isOnResignYes(core::MousePos mousePos) const;
+  [[nodiscard]] bool isOnResignNo(core::MousePos mousePos) const;
+
+  void showGameOverPopup(const std::string &msg);
+  void hideGameOverPopup();
+  [[nodiscard]] bool isGameOverPopupOpen() const;
+  [[nodiscard]] bool isOnNewBot(core::MousePos mousePos) const;
+  [[nodiscard]] bool isOnRematch(core::MousePos mousePos) const;
 
   [[nodiscard]] core::Square mousePosToSquare(core::MousePos mousePos) const;
   void setPieceToMouseScreenPos(core::Square pos, core::MousePos mousePos);
@@ -105,6 +122,22 @@ private:
   MoveListView m_move_list;
   PlayerInfoView m_top_player;
   PlayerInfoView m_bottom_player;
+
+  // popups
+  sf::Font m_font;
+  bool m_show_resign{false};
+  bool m_show_game_over{false};
+  sf::RectangleShape m_popup_bg;
+  sf::Text m_popup_msg;
+  sf::Text m_popup_yes;
+  sf::Text m_popup_no;
+  sf::FloatRect m_yes_bounds;
+  sf::FloatRect m_no_bounds;
+  sf::Text m_go_msg;
+  sf::Text m_go_new_bot;
+  sf::Text m_go_rematch;
+  sf::FloatRect m_nb_bounds;
+  sf::FloatRect m_rm_bounds;
 };
 
 } // namespace lilia::view

--- a/include/lilia/view/move_list_view.hpp
+++ b/include/lilia/view/move_list_view.hpp
@@ -20,6 +20,7 @@ public:
   void setSize(unsigned int width, unsigned int height);
 
   void addMove(const std::string &uciMove);
+  void addResult(const std::string &result);
   void setCurrentMove(std::size_t moveIndex);
   void render(sf::RenderWindow &window) const;
   void scroll(float delta);
@@ -29,17 +30,38 @@ public:
 
   [[nodiscard]] std::size_t getMoveIndexAt(const Entity::Position &pos) const;
 
+  enum class Option { None, Resign, Prev, Next, Settings, NewBot, Rematch };
+  [[nodiscard]] Option getOptionAt(const Entity::Position &pos) const;
+  void setGameOver(bool over);
+
 private:
   sf::Font m_font;
   std::vector<std::string> m_lines;
+  std::string m_result;
   Entity::Position m_position{}; // Top-left position
   unsigned int m_width{constant::MOVE_LIST_WIDTH};
   unsigned int m_height{constant::WINDOW_PX_SIZE};
+  float m_option_height{0.f};
   float m_scroll_offset{0.f};
   std::size_t m_move_count{0};
   std::size_t m_selected_move{static_cast<std::size_t>(-1)};
   std::vector<sf::FloatRect> m_move_bounds;
   bool m_any_bot{false};
+  bool m_game_over{false};
+
+  // Icons in bottom option field
+  mutable Entity m_icon_resign;
+  mutable Entity m_icon_prev;
+  mutable Entity m_icon_next;
+  mutable Entity m_icon_settings;
+  mutable Entity m_icon_new_bot;
+  mutable Entity m_icon_rematch;
+  sf::FloatRect m_bounds_resign{};
+  sf::FloatRect m_bounds_prev{};
+  sf::FloatRect m_bounds_next{};
+  sf::FloatRect m_bounds_settings{};
+  sf::FloatRect m_bounds_new_bot{};
+  sf::FloatRect m_bounds_rematch{};
 };
 
 } // namespace lilia::view

--- a/include/lilia/view/render_constants.hpp
+++ b/include/lilia/view/render_constants.hpp
@@ -57,6 +57,12 @@ const std::string STR_FILE_PATH_FLIP = "assets/icons/flip.png";
 const std::string STR_FILE_PATH_ICON_LILIA = "assets/icons/lilia.png";
 const std::string STR_FILE_PATH_ICON_LILIA_START_SCREEN = "assets/icons/lilia_logo.png";
 const std::string STR_FILE_PATH_ICON_CHALLENGER = "assets/icons/challenger.png";
+const std::string STR_FILE_PATH_ICON_RESIGN = "assets/icons/resign.png";
+const std::string STR_FILE_PATH_ICON_PREV = "assets/icons/prev.png";
+const std::string STR_FILE_PATH_ICON_NEXT = "assets/icons/next.png";
+const std::string STR_FILE_PATH_ICON_SETTINGS = "assets/icons/settings.png";
+const std::string STR_FILE_PATH_ICON_NEW_BOT = "assets/icons/new_bot.png";
+const std::string STR_FILE_PATH_ICON_REMATCH = "assets/icons/rematch.png";
 
 const std::string ASSET_PIECES_FILE_PATH = "assets/textures";
 constexpr float ASSET_PIECE_SCALE = 1.6f;

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -21,32 +21,49 @@ int App::run() {
                     lilia::view::constant::WINDOW_TOTAL_HEIGHT),
       "Lilia", sf::Style::Titlebar | sf::Style::Close);
 
-  lilia::view::StartScreen startScreen(window);
-  auto cfg = startScreen.run();
-  m_white_is_bot = cfg.whiteIsBot;
-  m_black_is_bot = cfg.blackIsBot;
+  while (window.isOpen()) {
+    lilia::view::StartScreen startScreen(window);
+    auto cfg = startScreen.run();
+    m_white_is_bot = cfg.whiteIsBot;
+    m_black_is_bot = cfg.blackIsBot;
 
-  {
-    lilia::model::ChessGame chessGame;
-    lilia::view::GameView gameView(window, m_black_is_bot, m_white_is_bot);
-    lilia::controller::GameController gameController(gameView, chessGame);
+    lilia::controller::GameController::NextAction action =
+        lilia::controller::GameController::NextAction::None;
 
-    gameController.startGame(m_start_fen, m_white_is_bot, m_black_is_bot,
-                             m_thinkTimeMs, m_searchDepth);
+    do {
+      lilia::model::ChessGame chessGame;
+      lilia::view::GameView gameView(window, m_black_is_bot, m_white_is_bot);
+      lilia::controller::GameController gameController(gameView, chessGame);
 
-    sf::Clock clock;
-    while (window.isOpen()) {
-      float deltaSeconds = clock.restart().asSeconds();
-      sf::Event event;
-      while (window.pollEvent(event)) {
-        if (event.type == sf::Event::Closed) window.close();
-        gameController.handleEvent(event);
+      gameController.startGame(m_start_fen, m_white_is_bot, m_black_is_bot,
+                               m_thinkTimeMs, m_searchDepth);
+
+      sf::Clock clock;
+      while (window.isOpen() &&
+             gameController.getNextAction() ==
+                 lilia::controller::GameController::NextAction::None) {
+        float deltaSeconds = clock.restart().asSeconds();
+        sf::Event event;
+        while (window.pollEvent(event)) {
+          if (event.type == sf::Event::Closed) window.close();
+          gameController.handleEvent(event);
+        }
+        gameController.update(deltaSeconds);
+        window.clear(sf::Color{48, 46, 43});
+        gameController.render();
+        window.display();
       }
-      gameController.update(deltaSeconds);
-      window.clear(sf::Color{48, 46, 43});
-      gameController.render();
-      window.display();
-    }
+
+      if (!window.isOpen()) return 0;
+
+      action = gameController.getNextAction();
+
+    } while (action ==
+             lilia::controller::GameController::NextAction::Rematch &&
+             window.isOpen());
+
+    if (action != lilia::controller::GameController::NextAction::NewBot)
+      break;
   }
 
   return 0;

--- a/src/lilia/model/chess_game.cpp
+++ b/src/lilia/model/chess_game.cpp
@@ -200,6 +200,8 @@ core::GameResult ChessGame::getResult() {
   return m_result;
 }
 
+void ChessGame::setResult(core::GameResult res) { m_result = res; }
+
 bb::Piece ChessGame::getPiece(core::Square sq) {
   bb::Piece none;
   if (m_position.getBoard().getPiece(sq).has_value())


### PR DESCRIPTION
## Summary
- Track post-game actions in the controller so players can resign, start a new bot game, or request a rematch
- Render final scores in the move list and expose new bot/rematch buttons after a game ends
- Loop application flow to handle rematches or returning to the start screen

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b4501aa3c08329adc5362337ec2673