### PR TITLE
Keep piece selection after opponent move

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -86,6 +86,7 @@ private:
 
   void snapAndReturn(core::Square sq, core::MousePos cur);
   void highlightLastMove();
+  void clearLastMoveHighlight();
 
   [[nodiscard]] std::vector<core::Square>
   getAttackSquares(core::Square pieceSQ) const;

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -363,6 +363,13 @@ void GameController::deselectSquare() {
   m_selected_sq = core::NO_SQUARE;
 }
 
+void GameController::clearLastMoveHighlight() {
+  if (isValid(m_last_move_squares.first))
+    m_game_view.clearHighlightSquare(m_last_move_squares.first);
+  if (isValid(m_last_move_squares.second))
+    m_game_view.clearHighlightSquare(m_last_move_squares.second);
+}
+
 void GameController::hoverSquare(core::Square sq) {
   m_hover_sq = sq;
   m_game_view.highlightHoverSquare(m_hover_sq);
@@ -438,9 +445,11 @@ void GameController::movePieceAndClear(const model::Move &move,
   }
 
   // 6) Visuals / Sounds
+  clearLastMoveHighlight();
   m_last_move_squares = {from, to};
-  deselectSquare();
   highlightLastMove();
+  if (isValid(m_selected_sq))
+    m_game_view.highlightSquare(m_selected_sq);
 
   const core::Color sideToMoveNow = m_chess_game.getGameState().sideToMove;
 


### PR DESCRIPTION
## Summary
- preserve currently selected square when opponent makes a move
- clear only previous move highlights and keep user selection intact

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: undefined reference to X11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b468aaa95083298d3276bcebcf51e1