### PR TITLE
Fix board orientation when black starts against bot

### DIFF
--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -41,7 +41,6 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
     topInfo = getBotInfo(BotType::Lilia);
   } else {
     topInfo = {"Challenger", 0, constant::STR_FILE_PATH_ICON_CHALLENGER};
-    m_board_view.setFlipped(true);
   }
   m_top_player.setInfo(topInfo);
 
@@ -50,9 +49,11 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
     bottomInfo = getBotInfo(BotType::Lilia);
   } else {
     bottomInfo = {"Challenger", 0, constant::STR_FILE_PATH_ICON_CHALLENGER};
-    m_board_view.setFlipped(false);
   }
   m_bottom_player.setInfo(bottomInfo);
+
+  // If black is a player but white is not, start with the board flipped.
+  m_board_view.setFlipped(bottomIsBot && !topIsBot);
 
   layout(m_window.getSize().x, m_window.getSize().y);
 


### PR DESCRIPTION
## Summary
- ensure board flips at game start when black is the only human player

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY OPENGL_INCLUDE_DIR))*

------
https://chatgpt.com/codex/tasks/task_e_68b46ef1470c8329b21c680321b2c3d2