### PR TITLE
Display result on game end and smooth eval bar

### DIFF
--- a/include/lilia/view/eval_bar.hpp
+++ b/include/lilia/view/eval_bar.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "entity.hpp"
 #include <SFML/Graphics/Text.hpp>
+#include <string>
 
 namespace sf {
 class RenderWindow;
@@ -15,6 +16,7 @@ class EvalBar : Entity {
   virtual void setPosition(const Entity::Position &pos) override;
   void render(sf::RenderWindow &window);
   void update(int eval);
+  void setResult(const std::string &result);
 
  private:
   void scaleToEval(float e);
@@ -24,6 +26,7 @@ class EvalBar : Entity {
   sf::Text m_score_text;
   float m_display_eval{0.f};
   float m_target_eval{0.f};
+  std::string m_result;
 };
 
 }  // namespace lilia::view

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -5,6 +5,7 @@
 #include <SFML/Graphics/Text.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <SFML/Window/Cursor.hpp>
+#include <string>
 
 #include "../constants.hpp"
 #include "../controller/mousepos.hpp"
@@ -33,6 +34,7 @@ public:
 
   void update(float dt);
   void updateEval(int eval);
+  void setEvalResult(const std::string &result);
 
   void render();
 

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -70,7 +70,6 @@ GameController::GameController(view::GameView &gView, model::ChessGame &game)
 
   m_game_manager->setOnGameEnd([this](core::GameResult res) {
     this->showGameOver(res, m_chess_game.getGameState().sideToMove);
-    this->m_sound_manager.playEffect(view::sound::Effect::GameEnds);
   });
 }
 
@@ -743,25 +742,26 @@ bool GameController::hasCurrentLegalMove(core::Square from, core::Square to) con
 
 void GameController::showGameOver(core::GameResult res, core::Color sideToMove) {
   std::string resultStr;
+  m_sound_manager.playEffect(view::sound::Effect::GameEnds);
   switch (res) {
     case core::GameResult::CHECKMATE:
       resultStr = (sideToMove == core::Color::White) ? "0-1" : "1-0";
       m_game_view.showGameOverPopup(sideToMove == core::Color::White ? "Black won" : "White won");
       break;
     case core::GameResult::REPETITION:
-      resultStr = "1/2-1/2";
+      resultStr = "1/2 - 1/2";
       m_game_view.showGameOverPopup("Draw by repetition");
       break;
     case core::GameResult::MOVERULE:
-      resultStr = "1/2-1/2";
+      resultStr = "1/2 - 1/2";
       m_game_view.showGameOverPopup("Draw by 50 move rule");
       break;
     case core::GameResult::STALEMATE:
-      resultStr = "1/2-1/2";
+      resultStr = "1/2 - 1/2";
       m_game_view.showGameOverPopup("Stalemate");
       break;
     case core::GameResult::INSUFFICIENT:
-      resultStr = "1/2-1/2";
+      resultStr = "1/2 - 1/2";
       m_game_view.showGameOverPopup("Insufficient material");
       break;
     default:
@@ -770,6 +770,7 @@ void GameController::showGameOver(core::GameResult res, core::Color sideToMove) 
       break;
   }
   m_game_view.addResult(resultStr);
+  m_game_view.setEvalResult(resultStr);
   m_game_view.setGameOver(true);
 }
 

--- a/src/lilia/view/eval_bar.cpp
+++ b/src/lilia/view/eval_bar.cpp
@@ -51,8 +51,10 @@ void EvalBar::render(sf::RenderWindow &window) {
   window.draw(m_score_text);
 }
 void EvalBar::update(int eval) {
+  if (!m_result.empty()) return;
+
   m_target_eval = static_cast<float>(eval);
-  m_display_eval += (m_target_eval - m_display_eval) * 0.1f;
+  m_display_eval = std::lerp(m_display_eval, m_target_eval, 0.05f);
   scaleToEval(m_display_eval);
 
   int absEval = std::abs(eval);
@@ -128,6 +130,18 @@ void EvalBar::scaleToEval(float e) {
     m_black_background.setScale(W / bgOrig.x, H / bgOrig.y);
     m_black_background.setPosition(p);
   }
+}
+
+void EvalBar::setResult(const std::string &result) {
+  m_result = result;
+  if (m_result.empty()) return;
+
+  m_score_text.setString(m_result);
+  m_score_text.setFillColor(sf::Color::White);
+  auto b = m_score_text.getLocalBounds();
+  m_score_text.setOrigin(b.width / 2.f, b.height / 2.f);
+  m_score_text.setPosition(std::round(getPosition().x),
+                           std::round(getPosition().y));
 }
 
 } // namespace lilia::view

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -83,6 +83,8 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
 void GameView::init(const std::string &fen) {
   m_board_view.init();
   m_piece_manager.initFromFen(fen);
+  m_eval_bar.setResult("");
+  m_eval_bar.update(0);
 }
 
 void GameView::update(float dt) {
@@ -91,6 +93,10 @@ void GameView::update(float dt) {
 
 void GameView::updateEval(int eval) {
   m_eval_bar.update(eval);
+}
+
+void GameView::setEvalResult(const std::string &result) {
+  m_eval_bar.setResult(result);
 }
 
 void GameView::render() {

--- a/src/lilia/view/move_list_view.cpp
+++ b/src/lilia/view/move_list_view.cpp
@@ -233,11 +233,25 @@ void MoveListView::render(sf::RenderWindow &window) const {
     std::string blackMove;
     std::string result;
     if (tokens.size() > 2) {
-      if (tokens[2] == "1-0" || tokens[2] == "0-1" || tokens[2] == "1/2-1/2") {
-        result = tokens[2];
+      // Join remaining tokens and decide whether they represent a result
+      auto joinFrom = [&](std::size_t idx) {
+        std::string tmp;
+        for (std::size_t j = idx; j < tokens.size(); ++j) {
+          if (j > idx) tmp += " ";
+          tmp += tokens[j];
+        }
+        return tmp;
+      };
+
+      std::string rem = joinFrom(2);
+      if (rem == "1-0" || rem == "0-1" || rem == "1/2 - 1/2") {
+        result = rem;
       } else {
         blackMove = tokens[2];
-        if (tokens.size() > 3) result = tokens[3];
+        rem = joinFrom(3);
+        if (rem == "1-0" || rem == "0-1" || rem == "1/2 - 1/2") {
+          result = rem;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Smooth evaluation bar transitions with lerp
- Show final game result on eval bar and move list
- Always play GameEnds sound when a game finishes

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b46faa4d2c8329848233fb769fa089