### PR TITLE
Smooth eval bar and correct game end handling

### DIFF
--- a/include/lilia/view/eval_bar.hpp
+++ b/include/lilia/view/eval_bar.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "entity.hpp"
 #include <SFML/Graphics/Text.hpp>
+#include <string>
 
 namespace sf {
 class RenderWindow;
@@ -15,6 +16,8 @@ class EvalBar : Entity {
   virtual void setPosition(const Entity::Position &pos) override;
   void render(sf::RenderWindow &window);
   void update(int eval);
+  void setResult(const std::string &result);
+  void reset();
 
  private:
   void scaleToEval(float e);
@@ -24,6 +27,8 @@ class EvalBar : Entity {
   sf::Text m_score_text;
   float m_display_eval{0.f};
   float m_target_eval{0.f};
+  bool m_has_result{false};
+  std::string m_result;
 };
 
 }  // namespace lilia::view

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -70,7 +70,6 @@ GameController::GameController(view::GameView &gView, model::ChessGame &game)
 
   m_game_manager->setOnGameEnd([this](core::GameResult res) {
     this->showGameOver(res, m_chess_game.getGameState().sideToMove);
-    this->m_sound_manager.playEffect(view::sound::Effect::GameEnds);
   });
 }
 
@@ -744,6 +743,7 @@ bool GameController::hasCurrentLegalMove(core::Square from, core::Square to) con
 }
 
 void GameController::showGameOver(core::GameResult res, core::Color sideToMove) {
+  m_sound_manager.playEffect(view::sound::Effect::GameEnds);
   std::string resultStr;
   switch (res) {
     case core::GameResult::CHECKMATE:

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -84,6 +84,8 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
 void GameView::init(const std::string &fen) {
   m_board_view.init();
   m_piece_manager.initFromFen(fen);
+  m_move_list.clear();
+  m_eval_bar.reset();
 }
 
 void GameView::update(float dt) {
@@ -131,6 +133,7 @@ void GameView::addMove(const std::string &move) {
 
 void GameView::addResult(const std::string &result) {
   m_move_list.addResult(result);
+  m_eval_bar.setResult(result);
 }
 
 void GameView::selectMove(std::size_t moveIndex) {

--- a/src/lilia/view/move_list_view.cpp
+++ b/src/lilia/view/move_list_view.cpp
@@ -228,16 +228,23 @@ void MoveListView::render(sf::RenderWindow &window) const {
     std::vector<std::string> tokens;
     std::string tok;
     while (iss >> tok) tokens.push_back(tok);
-    std::string numberStr = tokens.size() > 0 ? tokens[0] : "";
-    std::string whiteMove = tokens.size() > 1 ? tokens[1] : "";
+    std::string numberStr;
+    std::string whiteMove;
     std::string blackMove;
     std::string result;
-    if (tokens.size() > 2) {
-      if (tokens[2] == "1-0" || tokens[2] == "0-1" || tokens[2] == "1/2-1/2") {
-        result = tokens[2];
-      } else {
-        blackMove = tokens[2];
-        if (tokens.size() > 3) result = tokens[3];
+    if (tokens.size() == 1 &&
+        (tokens[0] == "1-0" || tokens[0] == "0-1" || tokens[0] == "1/2-1/2")) {
+      result = tokens[0];
+    } else {
+      numberStr = tokens.size() > 0 ? tokens[0] : "";
+      whiteMove = tokens.size() > 1 ? tokens[1] : "";
+      if (tokens.size() > 2) {
+        if (tokens[2] == "1-0" || tokens[2] == "0-1" || tokens[2] == "1/2-1/2") {
+          result = tokens[2];
+        } else {
+          blackMove = tokens[2];
+          if (tokens.size() > 3) result = tokens[3];
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Smooth eval bar updates and show final results instead of numeric scores
- Ensure move list displays the game result in its final column
- Always play GameEnds sound and reset UI elements on new games

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b4743b587c83299c51be74a15782e2