### PR TITLE
feat: add confetti game over popup

### DIFF
--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/Graphics/CircleShape.hpp>
 #include <SFML/Graphics/RectangleShape.hpp>
+#include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/Graphics/Text.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <SFML/Window/Cursor.hpp>
@@ -19,6 +20,7 @@
 #include "promotion_manager.hpp"
 
 #include <functional>
+#include <vector>
 
 namespace lilia::view {
 
@@ -60,8 +62,9 @@ public:
   [[nodiscard]] bool isOnRematch(core::MousePos mousePos) const;
 
   [[nodiscard]] core::Square mousePosToSquare(core::MousePos mousePos) const;
-  [[nodiscard]] core::MousePos clampPosToBoard(
-      core::MousePos mousePos, Entity::Position pieceSize = {0.f, 0.f}) const;
+  [[nodiscard]] core::MousePos clampPosToBoard(core::MousePos mousePos,
+                                               Entity::Position pieceSize = {
+                                                   0.f, 0.f}) const;
   void setPieceToMouseScreenPos(core::Square pos, core::MousePos mousePos);
   void setPieceToSquareScreenPos(core::Square from, core::Square to);
 
@@ -140,6 +143,13 @@ private:
   sf::Text m_go_rematch;
   sf::FloatRect m_nb_bounds;
   sf::FloatRect m_rm_bounds;
+
+  struct ConfettiParticle {
+    sf::CircleShape shape;
+    sf::Vector2f velocity;
+  };
+  std::vector<ConfettiParticle> m_confetti;
+  float m_confetti_time{0.f};
 };
 
 } // namespace lilia::view

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -5,6 +5,8 @@
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/Graphics/Text.hpp>
 #include <algorithm>
+#include <cmath>
+#include <random>
 
 #include "lilia/bot/bot_info.hpp"
 #include "lilia/view/render_constants.hpp"
@@ -13,26 +15,23 @@
 namespace lilia::view {
 
 GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
-    : m_window(window),
-      m_board_view(),
-      m_piece_manager(m_board_view),
+    : m_window(window), m_board_view(), m_piece_manager(m_board_view),
       m_highlight_manager(m_board_view),
-      m_chess_animator(m_board_view, m_piece_manager),
-      m_eval_bar(),
-      m_move_list(),
-      m_top_player(),
-      m_bottom_player() {
+      m_chess_animator(m_board_view, m_piece_manager), m_eval_bar(),
+      m_move_list(), m_top_player(), m_bottom_player() {
   m_cursor_default.loadFromSystem(sf::Cursor::Arrow);
 
   sf::Image openImg;
   if (openImg.loadFromFile(constant::STR_FILE_PATH_HAND_OPEN)) {
-    m_cursor_hand_open.loadFromPixels(openImg.getPixelsPtr(), openImg.getSize(),
-                                      {openImg.getSize().x / 3, openImg.getSize().y / 3});
+    m_cursor_hand_open.loadFromPixels(
+        openImg.getPixelsPtr(), openImg.getSize(),
+        {openImg.getSize().x / 3, openImg.getSize().y / 3});
   }
   sf::Image closedImg;
   if (closedImg.loadFromFile(constant::STR_FILE_PATH_HAND_CLOSED)) {
-    m_cursor_hand_closed.loadFromPixels(closedImg.getPixelsPtr(), closedImg.getSize(),
-                                        {openImg.getSize().x / 3, openImg.getSize().y / 3});
+    m_cursor_hand_closed.loadFromPixels(
+        closedImg.getPixelsPtr(), closedImg.getSize(),
+        {openImg.getSize().x / 3, openImg.getSize().y / 3});
   }
   m_window.setMouseCursor(m_cursor_default);
 
@@ -60,7 +59,8 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
   m_font.loadFromFile(constant::STR_FILE_PATH_FONT);
   m_popup_bg.setFillColor(sf::Color(40, 40, 40, 220));
   m_popup_bg.setSize({300.f, 150.f});
-  m_popup_bg.setOrigin(m_popup_bg.getSize().x / 2.f, m_popup_bg.getSize().y / 2.f);
+  m_popup_bg.setOrigin(m_popup_bg.getSize().x / 2.f,
+                       m_popup_bg.getSize().y / 2.f);
   m_popup_msg.setFont(m_font);
   m_popup_msg.setCharacterSize(20);
   m_popup_msg.setFillColor(sf::Color::White);
@@ -90,11 +90,18 @@ void GameView::init(const std::string &fen) {
 
 void GameView::update(float dt) {
   m_chess_animator.updateAnimations(dt);
+  if (m_confetti_time > 0.f) {
+    m_confetti_time -= dt;
+    for (auto &p : m_confetti) {
+      p.shape.move(p.velocity * dt);
+    }
+    if (m_confetti_time <= 0.f) {
+      m_confetti.clear();
+    }
+  }
 }
 
-void GameView::updateEval(int eval) {
-  m_eval_bar.update(eval);
-}
+void GameView::updateEval(int eval) { m_eval_bar.update(eval); }
 
 void GameView::render() {
   m_eval_bar.render(m_window);
@@ -110,10 +117,15 @@ void GameView::render() {
   m_move_list.render(m_window);
 
   if (m_show_resign || m_show_game_over) {
-    sf::RectangleShape overlay(
-        {static_cast<float>(m_window.getSize().x), static_cast<float>(m_window.getSize().y)});
+    sf::RectangleShape overlay({static_cast<float>(m_window.getSize().x),
+                                static_cast<float>(m_window.getSize().y)});
     overlay.setFillColor(sf::Color(0, 0, 0, 100));
     m_window.draw(overlay);
+    if (m_confetti_time > 0.f) {
+      for (auto &p : m_confetti) {
+        m_window.draw(p.shape);
+      }
+    }
     m_window.draw(m_popup_bg);
     if (m_show_resign) {
       m_window.draw(m_popup_msg);
@@ -127,9 +139,7 @@ void GameView::render() {
   }
 }
 
-void GameView::addMove(const std::string &move) {
-  m_move_list.addMove(move);
-}
+void GameView::addMove(const std::string &move) { m_move_list.addMove(move); }
 
 void GameView::addResult(const std::string &result) {
   m_move_list.addResult(result);
@@ -147,27 +157,21 @@ void GameView::setBoardFen(const std::string &fen) {
   m_highlight_manager.clearAllHighlights();
 }
 
-void GameView::scrollMoveList(float delta) {
-  m_move_list.scroll(delta);
-}
+void GameView::scrollMoveList(float delta) { m_move_list.scroll(delta); }
 
-void GameView::setBotMode(bool anyBot) {
-  m_move_list.setBotMode(anyBot);
-}
+void GameView::setBotMode(bool anyBot) { m_move_list.setBotMode(anyBot); }
 
 std::size_t GameView::getMoveIndexAt(core::MousePos mousePos) const {
-  return m_move_list.getMoveIndexAt(
-      Entity::Position{static_cast<float>(mousePos.x), static_cast<float>(mousePos.y)});
+  return m_move_list.getMoveIndexAt(Entity::Position{
+      static_cast<float>(mousePos.x), static_cast<float>(mousePos.y)});
 }
 
 MoveListView::Option GameView::getOptionAt(core::MousePos mousePos) const {
-  return m_move_list.getOptionAt(
-      Entity::Position{static_cast<float>(mousePos.x), static_cast<float>(mousePos.y)});
+  return m_move_list.getOptionAt(Entity::Position{
+      static_cast<float>(mousePos.x), static_cast<float>(mousePos.y)});
 }
 
-void GameView::setGameOver(bool over) {
-  m_move_list.setGameOver(over);
-}
+void GameView::setGameOver(bool over) { m_move_list.setGameOver(over); }
 
 void GameView::showResignPopup() {
   m_show_resign = true;
@@ -176,7 +180,8 @@ void GameView::showResignPopup() {
   m_popup_msg.setString("Do you really want to resign?");
   auto b = m_popup_msg.getLocalBounds();
   m_popup_msg.setOrigin(b.left + b.width / 2.f, b.top + b.height / 2.f);
-  m_popup_msg.setPosition(m_popup_bg.getPosition().x, m_popup_bg.getPosition().y - 20.f);
+  m_popup_msg.setPosition(m_popup_bg.getPosition().x,
+                          m_popup_bg.getPosition().y - 20.f);
   m_popup_yes.setString("Yes");
   m_popup_no.setString("No");
   auto yb = m_popup_yes.getLocalBounds();
@@ -191,30 +196,29 @@ void GameView::showResignPopup() {
   m_no_bounds = m_popup_no.getGlobalBounds();
 }
 
-void GameView::hideResignPopup() {
-  m_show_resign = false;
-}
+void GameView::hideResignPopup() { m_show_resign = false; }
 
-bool GameView::isResignPopupOpen() const {
-  return m_show_resign;
-}
+bool GameView::isResignPopupOpen() const { return m_show_resign; }
 
 bool GameView::isOnResignYes(core::MousePos mousePos) const {
-  return m_yes_bounds.contains(static_cast<float>(mousePos.x), static_cast<float>(mousePos.y));
+  return m_yes_bounds.contains(static_cast<float>(mousePos.x),
+                               static_cast<float>(mousePos.y));
 }
 
 bool GameView::isOnResignNo(core::MousePos mousePos) const {
-  return m_no_bounds.contains(static_cast<float>(mousePos.x), static_cast<float>(mousePos.y));
+  return m_no_bounds.contains(static_cast<float>(mousePos.x),
+                              static_cast<float>(mousePos.y));
 }
 
 void GameView::showGameOverPopup(const std::string &msg) {
   m_show_game_over = true;
-  m_popup_bg.setPosition(static_cast<float>(m_window.getSize().x) / 2.f,
-                         static_cast<float>(m_window.getSize().y) / 2.f);
+  auto center = m_board_view.getPosition();
+  m_popup_bg.setPosition(center.x, center.y);
   m_go_msg.setString(msg);
   auto b = m_go_msg.getLocalBounds();
   m_go_msg.setOrigin(b.left + b.width / 2.f, b.top + b.height / 2.f);
-  m_go_msg.setPosition(m_popup_bg.getPosition().x, m_popup_bg.getPosition().y - 20.f);
+  m_go_msg.setPosition(m_popup_bg.getPosition().x,
+                       m_popup_bg.getPosition().y - 20.f);
   m_go_new_bot.setString("New Bot");
   m_go_rematch.setString("Rematch");
   auto nb = m_go_new_bot.getLocalBounds();
@@ -227,52 +231,90 @@ void GameView::showGameOverPopup(const std::string &msg) {
   m_go_rematch.setPosition(cx + 60.f, cy);
   m_nb_bounds = m_go_new_bot.getGlobalBounds();
   m_rm_bounds = m_go_rematch.getGlobalBounds();
+
+  if (msg.find("won") != std::string::npos) {
+    m_confetti_time = 1.f;
+    m_confetti.clear();
+    std::mt19937 rng(std::random_device{}());
+    constexpr float TWO_PI = 6.2831853f;
+    std::uniform_real_distribution<float> angleDist(0.f, TWO_PI);
+    std::uniform_real_distribution<float> speedDist(100.f, 200.f);
+    std::uniform_real_distribution<float> radiusDist(2.f, 4.f);
+    std::uniform_int_distribution<int> colorDist(0, 255);
+    for (int i = 0; i < 100; ++i) {
+      float angle = angleDist(rng);
+      float speed = speedDist(rng);
+      float radius = radiusDist(rng);
+      sf::CircleShape shape(radius);
+      shape.setFillColor(
+          sf::Color(colorDist(rng), colorDist(rng), colorDist(rng)));
+      shape.setOrigin(radius, radius);
+      shape.setPosition(center.x, center.y);
+      ConfettiParticle p{shape,
+                         {std::cos(angle) * speed, std::sin(angle) * speed}};
+      m_confetti.push_back(p);
+    }
+  }
 }
 
 void GameView::hideGameOverPopup() {
   m_show_game_over = false;
+  m_confetti_time = 0.f;
+  m_confetti.clear();
 }
 
-bool GameView::isGameOverPopupOpen() const {
-  return m_show_game_over;
-}
+bool GameView::isGameOverPopupOpen() const { return m_show_game_over; }
 
 bool GameView::isOnNewBot(core::MousePos mousePos) const {
-  return m_nb_bounds.contains(static_cast<float>(mousePos.x), static_cast<float>(mousePos.y));
+  return m_nb_bounds.contains(static_cast<float>(mousePos.x),
+                              static_cast<float>(mousePos.y));
 }
 
 bool GameView::isOnRematch(core::MousePos mousePos) const {
-  return m_rm_bounds.contains(static_cast<float>(mousePos.x), static_cast<float>(mousePos.y));
+  return m_rm_bounds.contains(static_cast<float>(mousePos.x),
+                              static_cast<float>(mousePos.y));
 }
 
 void GameView::layout(unsigned int width, unsigned int height) {
-  float vMargin = std::max(
-      0.f, (static_cast<float>(height) - static_cast<float>(constant::WINDOW_PX_SIZE)) / 2.f);
-  float hMargin = std::max(
-      0.f, (static_cast<float>(width) - static_cast<float>(constant::WINDOW_TOTAL_WIDTH)) / 2.f);
+  float vMargin = std::max(0.f, (static_cast<float>(height) -
+                                 static_cast<float>(constant::WINDOW_PX_SIZE)) /
+                                    2.f);
+  float hMargin =
+      std::max(0.f, (static_cast<float>(width) -
+                     static_cast<float>(constant::WINDOW_TOTAL_WIDTH)) /
+                        2.f);
 
-  float boardCenterX = hMargin +
-                       static_cast<float>(constant::EVAL_BAR_WIDTH + constant::SIDE_MARGIN) +
-                       static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
-  float boardCenterY = vMargin + static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
+  float boardCenterX =
+      hMargin +
+      static_cast<float>(constant::EVAL_BAR_WIDTH + constant::SIDE_MARGIN) +
+      static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
+  float boardCenterY =
+      vMargin + static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
 
   m_board_view.setPosition({boardCenterX, boardCenterY});
 
-  float evalCenterX =
-      hMargin + static_cast<float>(constant::EVAL_BAR_WIDTH + constant::SIDE_MARGIN) / 2.f;
+  float evalCenterX = hMargin + static_cast<float>(constant::EVAL_BAR_WIDTH +
+                                                   constant::SIDE_MARGIN) /
+                                    2.f;
   m_eval_bar.setPosition({evalCenterX, boardCenterY});
 
-  float moveListX = hMargin + static_cast<float>(constant::EVAL_BAR_WIDTH + constant::SIDE_MARGIN +
-                                                 constant::WINDOW_PX_SIZE + constant::SIDE_MARGIN);
+  float moveListX =
+      hMargin +
+      static_cast<float>(constant::EVAL_BAR_WIDTH + constant::SIDE_MARGIN +
+                         constant::WINDOW_PX_SIZE + constant::SIDE_MARGIN);
   m_move_list.setPosition({moveListX, vMargin});
   m_move_list.setSize(constant::MOVE_LIST_WIDTH, constant::WINDOW_PX_SIZE);
 
-  float boardLeft = boardCenterX - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
-  float boardTop = boardCenterY - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
+  float boardLeft =
+      boardCenterX - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
+  float boardTop =
+      boardCenterY - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f;
   // shift player info slightly to the right and adjust vertical placement
-  m_top_player.setPositionClamped({boardLeft + 5.f, boardTop - 45.f}, m_window.getSize());
+  m_top_player.setPositionClamped({boardLeft + 5.f, boardTop - 45.f},
+                                  m_window.getSize());
   m_bottom_player.setPositionClamped(
-      {boardLeft + 5.f, boardTop + static_cast<float>(constant::WINDOW_PX_SIZE) + 15.f},
+      {boardLeft + 5.f,
+       boardTop + static_cast<float>(constant::WINDOW_PX_SIZE) + 15.f},
       m_window.getSize());
 }
 
@@ -286,20 +328,26 @@ void GameView::warningKingSquareAnim(core::Square ksq) {
   m_chess_animator.declareHighlightLevel(ksq);
 }
 
-void GameView::animationSnapAndReturn(core::Square sq, core::MousePos mousePos) {
+void GameView::animationSnapAndReturn(core::Square sq,
+                                      core::MousePos mousePos) {
   m_chess_animator.snapAndReturn(sq, mousePos);
 }
 
-void GameView::animationMovePiece(core::Square from, core::Square to, core::Square enPSquare,
-                                  core::PieceType promotion, std::function<void()> onComplete) {
+void GameView::animationMovePiece(core::Square from, core::Square to,
+                                  core::Square enPSquare,
+                                  core::PieceType promotion,
+                                  std::function<void()> onComplete) {
   m_chess_animator.movePiece(from, to, promotion, std::move(onComplete));
-  if (enPSquare != core::NO_SQUARE) m_piece_manager.removePiece(enPSquare);
+  if (enPSquare != core::NO_SQUARE)
+    m_piece_manager.removePiece(enPSquare);
 }
 
-void GameView::animationDropPiece(core::Square from, core::Square to, core::Square enPSquare,
+void GameView::animationDropPiece(core::Square from, core::Square to,
+                                  core::Square enPSquare,
                                   core::PieceType promotion) {
   m_chess_animator.dropPiece(from, to, promotion);
-  if (enPSquare != core::NO_SQUARE) m_piece_manager.removePiece(enPSquare);
+  if (enPSquare != core::NO_SQUARE)
+    m_piece_manager.removePiece(enPSquare);
 }
 
 void GameView::playPiecePlaceHolderAnimation(core::Square sq) {
@@ -310,15 +358,14 @@ void GameView::playPromotionSelectAnim(core::Square promSq, core::Color c) {
   m_chess_animator.promotionSelect(promSq, m_promotion_manager, c);
 }
 
-void GameView::endAnimation(core::Square sq) {
-  m_chess_animator.end(sq);
-}
+void GameView::endAnimation(core::Square sq) { m_chess_animator.end(sq); }
 
 [[nodiscard]] bool GameView::hasPieceOnSquare(core::Square pos) const {
   return m_piece_manager.hasPieceOnSquare(pos);
 }
 
-[[nodiscard]] bool GameView::isSameColorPiece(core::Square sq1, core::Square sq2) const {
+[[nodiscard]] bool GameView::isSameColorPiece(core::Square sq1,
+                                              core::Square sq2) const {
   return m_piece_manager.isSameColor(sq1, sq2);
 }
 
@@ -330,7 +377,8 @@ void GameView::endAnimation(core::Square sq) {
   return m_piece_manager.getPieceColor(pos);
 }
 
-void GameView::addPiece(core::PieceType type, core::Color color, core::Square pos) {
+void GameView::addPiece(core::PieceType type, core::Color color,
+                        core::Square pos) {
   m_piece_manager.addPiece(type, color, pos);
 }
 
@@ -368,14 +416,16 @@ bool GameView::isInPromotionSelection() {
 }
 
 core::PieceType GameView::getSelectedPromotion(core::MousePos mousePos) {
-  return m_promotion_manager.clickedOnType(static_cast<Entity::Position>(mousePos));
+  return m_promotion_manager.clickedOnType(
+      static_cast<Entity::Position>(mousePos));
 }
 
 void GameView::removePromotionSelection() {
   m_promotion_manager.removeOptions();
 }
 
-[[nodiscard]] core::Square GameView::mousePosToSquare(core::MousePos mousePos) const {
+[[nodiscard]] core::Square
+GameView::mousePosToSquare(core::MousePos mousePos) const {
   return m_board_view.mousePosToSquare(mousePos);
 }
 
@@ -384,16 +434,15 @@ core::MousePos GameView::clampPosToBoard(core::MousePos mousePos,
   return m_board_view.clampPosToBoard(mousePos, pieceSize);
 }
 
-void GameView::setPieceToMouseScreenPos(core::Square pos, core::MousePos mousePos) {
+void GameView::setPieceToMouseScreenPos(core::Square pos,
+                                        core::MousePos mousePos) {
   auto size = getPieceSize(pos);
   m_piece_manager.setPieceToScreenPos(pos, clampPosToBoard(mousePos, size));
 }
 void GameView::setPieceToSquareScreenPos(core::Square from, core::Square to) {
   m_piece_manager.setPieceToSquareScreenPos(from, to);
 }
-void GameView::setDefaultCursor() {
-  m_window.setMouseCursor(m_cursor_default);
-}
+void GameView::setDefaultCursor() { m_window.setMouseCursor(m_cursor_default); }
 void GameView::setHandOpenCursor() {
   m_window.setMouseCursor(m_cursor_hand_open);
 }
@@ -401,20 +450,16 @@ void GameView::setHandClosedCursor() {
   m_window.setMouseCursor(m_cursor_hand_closed);
 }
 
-sf::Vector2u GameView::getWindowSize() const {
-  return m_window.getSize();
-}
+sf::Vector2u GameView::getWindowSize() const { return m_window.getSize(); }
 
 Entity::Position GameView::getPieceSize(core::Square pos) const {
   return m_piece_manager.getPieceSize(pos);
 }
 
-void GameView::toggleBoardOrientation() {
-  m_board_view.toggleFlipped();
-}
+void GameView::toggleBoardOrientation() { m_board_view.toggleFlipped(); }
 
 [[nodiscard]] bool GameView::isOnFlipIcon(core::MousePos mousePos) const {
   return m_board_view.isOnFlipIcon(mousePos);
 }
 
-}  // namespace lilia::view
+} // namespace lilia::view


### PR DESCRIPTION
## Summary
- center game over popup on chessboard
- add one-second confetti burst for winning results

## Testing
- `cmake -S . -B build` (fails: Could NOT find OpenGL)
- `cmake --build build` (fails: No rule to make target 'Makefile')

------
https://chatgpt.com/codex/tasks/task_e_68b47d11566c832991df02c285c6a386