### PR TITLE
Introduce particle system for win confetti

### DIFF
--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <SFML/Graphics/CircleShape.hpp>
 #include <SFML/Graphics/RectangleShape.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/Graphics/Text.hpp>
@@ -21,6 +20,7 @@
 
 #include <functional>
 #include <vector>
+#include "particle_system.hpp"
 
 namespace lilia::view {
 
@@ -144,12 +144,7 @@ private:
   sf::FloatRect m_nb_bounds;
   sf::FloatRect m_rm_bounds;
 
-  struct ConfettiParticle {
-    sf::CircleShape shape;
-    sf::Vector2f velocity;
-  };
-  std::vector<ConfettiParticle> m_confetti;
-  float m_confetti_time{0.f};
+  ParticleSystem m_particles;
 };
 
 } // namespace lilia::view

--- a/include/lilia/view/particle_system.hpp
+++ b/include/lilia/view/particle_system.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <SFML/Graphics/CircleShape.hpp>
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/System/Vector2.hpp>
+#include <vector>
+
+namespace lilia::view {
+
+class ParticleSystem {
+public:
+  struct Particle {
+    sf::CircleShape shape;
+    sf::Vector2f velocity;
+    float lifetime;
+  };
+
+  // Emit confetti across the board starting from the bottom edge.
+  void emitConfetti(const sf::Vector2f &center, float boardSize,
+                    std::size_t count);
+  void update(float dt);
+  void render(sf::RenderWindow &window);
+  void clear();
+  [[nodiscard]] bool empty() const;
+
+private:
+  std::vector<Particle> m_particles;
+};
+
+} // namespace lilia::view

--- a/src/lilia/view/particle_system.cpp
+++ b/src/lilia/view/particle_system.cpp
@@ -1,0 +1,55 @@
+#include "lilia/view/particle_system.hpp"
+
+#include <cmath>
+#include <random>
+
+namespace lilia::view {
+
+void ParticleSystem::emitConfetti(const sf::Vector2f &center, float boardSize,
+                                  std::size_t count) {
+  std::mt19937 rng(std::random_device{}());
+  std::uniform_real_distribution<float> xDist(center.x - boardSize / 2.f,
+                                              center.x + boardSize / 2.f);
+  std::uniform_real_distribution<float> vxDist(-50.f, 50.f);
+  std::uniform_real_distribution<float> vyDist(-250.f, -150.f);
+  std::uniform_real_distribution<float> radiusDist(2.f, 4.f);
+  std::uniform_int_distribution<int> colorDist(0, 255);
+
+  float startY = center.y + boardSize / 2.f;
+  for (std::size_t i = 0; i < count; ++i) {
+    float x = xDist(rng);
+    float radius = radiusDist(rng);
+    sf::CircleShape shape(radius);
+    shape.setFillColor(
+        sf::Color(colorDist(rng), colorDist(rng), colorDist(rng)));
+    shape.setOrigin(radius, radius);
+    shape.setPosition({x, startY});
+    sf::Vector2f velocity{vxDist(rng), vyDist(rng)};
+    Particle p{shape, velocity, 2.f};
+    m_particles.push_back(p);
+  }
+}
+
+void ParticleSystem::update(float dt) {
+  for (auto it = m_particles.begin(); it != m_particles.end();) {
+    it->lifetime -= dt;
+    if (it->lifetime <= 0.f) {
+      it = m_particles.erase(it);
+    } else {
+      it->shape.move(it->velocity * dt);
+      ++it;
+    }
+  }
+}
+
+void ParticleSystem::render(sf::RenderWindow &window) {
+  for (auto &p : m_particles) {
+    window.draw(p.shape);
+  }
+}
+
+void ParticleSystem::clear() { m_particles.clear(); }
+
+bool ParticleSystem::empty() const { return m_particles.empty(); }
+
+} // namespace lilia::view


### PR DESCRIPTION
## Summary
- create a reusable `ParticleSystem` to handle confetti particles
- refactor `GameView` to use `ParticleSystem` for win celebrations
- burst confetti upward from the board's bottom to cover the board on victory

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b48025dc7c8329a59800c97b593dcb