### PR TITLE
Add FEN start position input to start screen

### DIFF
--- a/include/lilia/view/start_screen.hpp
+++ b/include/lilia/view/start_screen.hpp
@@ -2,8 +2,10 @@
 
 #include <SFML/Graphics.hpp>
 #include <vector>
+#include <string>
 
 #include "lilia/bot/bot_info.hpp"
+#include "lilia/constants.hpp"
 
 namespace lilia::view {
 
@@ -12,6 +14,7 @@ struct StartConfig {
   BotType whiteBot{BotType::Lilia};
   bool blackIsBot{true};
   BotType blackBot{BotType::Lilia};
+  std::string fen{core::START_FEN};
 };
 
 struct BotOption {
@@ -55,8 +58,24 @@ class StartScreen {
   sf::Text m_startText;
   sf::Text m_creditText;
 
+  // FEN popup UI
+  bool m_showFenPopup{false};
+  sf::RectangleShape m_fenPopup;
+  sf::RectangleShape m_fenInputBox;
+  sf::Text m_fenInputText;
+  sf::RectangleShape m_fenBackBtn;
+  sf::RectangleShape m_fenContinueBtn;
+  sf::Text m_fenBackText;
+  sf::Text m_fenContinueText;
+  sf::Text m_fenErrorText;
+  std::string m_fenString;
+  sf::Clock m_errorClock;
+  bool m_showError{false};
+
   void setupUI();
   bool handleMouse(sf::Vector2f pos, StartConfig &cfg);
+  bool handleFenMouse(sf::Vector2f pos, StartConfig &cfg);
+  bool isValidFen(const std::string &fen);
 };
 
 }  // namespace lilia::view

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -26,6 +26,7 @@ int App::run() {
     auto cfg = startScreen.run();
     m_white_is_bot = cfg.whiteIsBot;
     m_black_is_bot = cfg.blackIsBot;
+    m_start_fen = cfg.fen;
 
     lilia::controller::GameController::NextAction action =
         lilia::controller::GameController::NextAction::None;


### PR DESCRIPTION
## Summary
- add popup on start screen to enter custom FEN and validate it
- highlight invalid FEN input and show fading error message
- pass selected FEN to game startup

## Testing
- `cmake .. && cmake --build .`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68b48bcf0c6c8329b2fd1038e9298a13