### PR TITLE
Enhance confetti particle motion

### DIFF
--- a/include/lilia/view/particle_system.hpp
+++ b/include/lilia/view/particle_system.hpp
@@ -13,6 +13,7 @@ public:
     sf::CircleShape shape;
     sf::Vector2f velocity;
     float lifetime;
+    float floorY; // y position where particle should disappear
   };
 
   // Emit confetti across the board starting from the bottom edge.


### PR DESCRIPTION
## Summary
- Add floor tracking to particles so they disappear when falling back to board bottom
- Increase launch speed and horizontal spread for more dynamic confetti
- Apply gravity and horizontal jitter for more natural fall motion

## Testing
- `cmake ..` *(fails: Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY OPENGL_INCLUDE_DIR))*

------
https://chatgpt.com/codex/tasks/task_e_68b4a2b2c88c832987cfb823c0c23227