### PR TITLE
Use selected bot configuration for engine search

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -22,7 +22,7 @@ class Event;
 namespace lilia::model {
 class ChessGame;
 struct Move;
-}  // namespace lilia::model
+} // namespace lilia::model
 
 namespace lilia::controller {
 class GameManager;
@@ -35,7 +35,7 @@ struct MoveView {
 };
 
 class GameController {
- public:
+public:
   explicit GameController(view::GameView &gView, model::ChessGame &game);
   ~GameController();
 
@@ -51,17 +51,23 @@ class GameController {
    * @param fen Start-FEN (default: START_FEN).
    * @param whiteIsBot true, falls der weiße Spieler ein Bot ist.
    * @param blackIsBot true, falls der schwarze Spieler ein Bot ist.
-   * @param thinkTimeMs Zeit in Millisekunden, die der Bot maximal denken darf.
-   * @param depth Suchtiefe für den Bot.
+   * @param whiteThinkTimeMs Zeit in Millisekunden, die der weiße Bot maximal
+   *            denken darf.
+   * @param whiteDepth Suchtiefe für den weißen Bot.
+   * @param blackThinkTimeMs Zeit in Millisekunden, die der schwarze Bot maximal
+   *            denken darf.
+   * @param blackDepth Suchtiefe für den schwarzen Bot.
    */
 
-  void startGame(const std::string &fen = core::START_FEN, bool whiteIsBot = false,
-                 bool blackIsBot = true, int thinkTimeMs = 1000, int depth = 5);
+  void startGame(const std::string &fen = core::START_FEN,
+                 bool whiteIsBot = false, bool blackIsBot = true,
+                 int whiteThinkTimeMs = 1000, int whiteDepth = 5,
+                 int blackThinkTimeMs = 1000, int blackDepth = 5);
 
   enum class NextAction { None, NewBot, Rematch };
   [[nodiscard]] NextAction getNextAction() const;
 
- private:
+private:
   bool isHumanPiece(core::Square sq) const;
   bool hasCurrentLegalMove(core::Square from, core::Square to) const;
 
@@ -80,13 +86,15 @@ class GameController {
   void dehoverSquare();
   void clearPremove();
 
-  void movePieceAndClear(const model::Move &move, bool isPlayerMove, bool onClick);
+  void movePieceAndClear(const model::Move &move, bool isPlayerMove,
+                         bool onClick);
 
   void snapAndReturn(core::Square sq, core::MousePos cur);
   void highlightLastMove();
   void clearLastMoveHighlight();
 
-  [[nodiscard]] std::vector<core::Square> getAttackSquares(core::Square pieceSQ) const;
+  [[nodiscard]] std::vector<core::Square>
+  getAttackSquares(core::Square pieceSQ) const;
   void showAttacks(std::vector<core::Square> att);
   [[nodiscard]] bool tryMove(core::Square a, core::Square b);
   [[nodiscard]] bool isPromotion(core::Square a, core::Square b);
@@ -98,10 +106,10 @@ class GameController {
   void resign();
 
   // ---------------- Members ----------------
-  view::GameView &m_game_view;                ///< Responsible for rendering.
-  model::ChessGame &m_chess_game;             ///< Game model containing rules and state.
-  InputManager m_input_manager;               ///< Handles raw input processing.
-  view::sound::SoundManager m_sound_manager;  ///< Handles sfx and music
+  view::GameView &m_game_view;    ///< Responsible for rendering.
+  model::ChessGame &m_chess_game; ///< Game model containing rules and state.
+  InputManager m_input_manager;   ///< Handles raw input processing.
+  view::sound::SoundManager m_sound_manager; ///< Handles sfx and music
 
   core::Square m_promotion_square = core::NO_SQUARE;
 
@@ -119,10 +127,10 @@ class GameController {
   core::Square m_pending_from = core::NO_SQUARE;
   core::Square m_pending_to = core::NO_SQUARE;
 
-  core::Square m_selected_sq = core::NO_SQUARE;  ///< Currently selected square.
-  core::Square m_hover_sq = core::NO_SQUARE;     ///< Currently hovered square.
+  core::Square m_selected_sq = core::NO_SQUARE; ///< Currently selected square.
+  core::Square m_hover_sq = core::NO_SQUARE;    ///< Currently hovered square.
   std::pair<core::Square, core::Square> m_last_move_squares = {
-      core::NO_SQUARE, core::NO_SQUARE};  ///< Last executed move (from -> to).
+      core::NO_SQUARE, core::NO_SQUARE}; ///< Last executed move (from -> to).
 
   // ---------------- New: GameManager ----------------
   std::unique_ptr<GameManager> m_game_manager;
@@ -134,4 +142,4 @@ class GameController {
   NextAction m_next_action{NextAction::None};
 };
 
-}  // namespace lilia::controller
+} // namespace lilia::controller

--- a/include/lilia/controller/game_manager.hpp
+++ b/include/lilia/controller/game_manager.hpp
@@ -12,7 +12,7 @@
 
 namespace lilia::model {
 class ChessGame;
-}  // namespace lilia::model
+} // namespace lilia::model
 
 namespace lilia::controller {
 struct IPlayer;
@@ -21,17 +21,19 @@ struct IPlayer;
 namespace lilia::controller {
 
 class GameManager {
- public:
-  using MoveCallback = std::function<void(const model::Move& mv, bool isPlayerMove, bool onClick)>;
+public:
+  using MoveCallback = std::function<void(const model::Move &mv,
+                                          bool isPlayerMove, bool onClick)>;
   using PromotionCallback = std::function<void(core::Square promotionSquare)>;
   using EndCallback = std::function<void(core::GameResult)>;
 
-  explicit GameManager(model::ChessGame& model);
+  explicit GameManager(model::ChessGame &model);
   ~GameManager();
 
-  void startGame(const std::string& fen = core::START_FEN,
+  void startGame(const std::string &fen = core::START_FEN,
                  bool whiteIsBot = false, bool blackIsBot = true,
-                 int thinkTimeMs = 1000, int depth = 5);
+                 int whiteThinkTimeMs = 1000, int whiteDepth = 5,
+                 int blackThinkTimeMs = 1000, int blackDepth = 5);
   void stopGame();
 
   void update(float dt);
@@ -41,7 +43,9 @@ class GameManager {
   void completePendingPromotion(core::PieceType promotion);
 
   void setOnMoveExecuted(MoveCallback cb) { onMoveExecuted_ = std::move(cb); }
-  void setOnPromotionRequested(PromotionCallback cb) { onPromotionRequested_ = std::move(cb); }
+  void setOnPromotionRequested(PromotionCallback cb) {
+    onPromotionRequested_ = std::move(cb);
+  }
   void setOnGameEnd(EndCallback cb) { onGameEnd_ = std::move(cb); }
 
   void setBotForColor(core::Color color, std::unique_ptr<IPlayer> bot);
@@ -49,15 +53,16 @@ class GameManager {
   [[nodiscard]] bool isHuman(core::Color color) const;
   [[nodiscard]] bool isHumanTurn() const;
 
- private:
-  model::ChessGame& m_game;
+private:
+  model::ChessGame &m_game;
   // Players: nullptr bedeutet menschlicher Spieler
   std::unique_ptr<IPlayer> m_white_player;
   std::unique_ptr<IPlayer> m_black_player;
 
   // Bot future & cancel token
   std::future<model::Move> m_bot_future;
-  IPlayer* m_pending_bot_player = nullptr;  // roher pointer auf den aktiven Player
+  IPlayer *m_pending_bot_player =
+      nullptr; // roher pointer auf den aktiven Player
   std::atomic<bool> m_cancel_bot{false};
 
   // pending promotion info
@@ -71,8 +76,8 @@ class GameManager {
   PromotionCallback onPromotionRequested_;
   EndCallback onGameEnd_;
 
-  void applyMoveAndNotify(const model::Move& mv, bool onClick);
+  void applyMoveAndNotify(const model::Move &mv, bool onClick);
   void startBotIfNeeded();
 };
 
-}  // namespace lilia::controller
+} // namespace lilia::controller

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -3,6 +3,7 @@
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/Window/Event.hpp>
 
+#include "lilia/bot/bot_info.hpp"
 #include "lilia/controller/game_controller.hpp"
 #include "lilia/engine/engine.hpp"
 #include "lilia/model/chess_game.hpp"
@@ -12,7 +13,8 @@
 
 namespace lilia::app {
 
-void drawVerticalGradient(sf::RenderWindow& window, sf::Color top, sf::Color bottom) {
+void drawVerticalGradient(sf::RenderWindow &window, sf::Color top,
+                          sf::Color bottom) {
   sf::VertexArray va(sf::TriangleStrip, 4);
   auto size = window.getSize();
   va[0].position = {0.f, 0.f};
@@ -28,9 +30,10 @@ int App::run() {
   engine::Engine::init();
   lilia::view::TextureTable::getInstance().preLoad();
 
-  sf::RenderWindow window(sf::VideoMode(lilia::view::constant::WINDOW_TOTAL_WIDTH,
-                                        lilia::view::constant::WINDOW_TOTAL_HEIGHT),
-                          "Lilia", sf::Style::Titlebar | sf::Style::Close);
+  sf::RenderWindow window(
+      sf::VideoMode(lilia::view::constant::WINDOW_TOTAL_WIDTH,
+                    lilia::view::constant::WINDOW_TOTAL_HEIGHT),
+      "Lilia", sf::Style::Titlebar | sf::Style::Close);
 
   while (window.isOpen()) {
     lilia::view::StartScreen startScreen(window);
@@ -38,8 +41,13 @@ int App::run() {
     bool m_white_is_bot = cfg.whiteIsBot;
     bool m_black_is_bot = cfg.blackIsBot;
     std::string m_start_fen = cfg.fen;
-    int m_searchDepth = 10;     // Search depth for bot
-    int m_thinkTimeMs = 10000;  // Bot think time in milliseconds
+
+    auto whiteCfg = getBotConfig(cfg.whiteBot);
+    auto blackCfg = getBotConfig(cfg.blackBot);
+    int whiteDepth = whiteCfg.depth;
+    int whiteThinkMs = whiteCfg.thinkTimeMs;
+    int blackDepth = blackCfg.depth;
+    int blackThinkMs = blackCfg.thinkTimeMs;
 
     lilia::controller::GameController::NextAction action =
         lilia::controller::GameController::NextAction::None;
@@ -50,34 +58,41 @@ int App::run() {
       lilia::view::GameView gameView(window, m_black_is_bot, m_white_is_bot);
       lilia::controller::GameController gameController(gameView, chessGame);
 
-      gameController.startGame(m_start_fen, m_white_is_bot, m_black_is_bot, m_thinkTimeMs,
-                               m_searchDepth);
+      gameController.startGame(m_start_fen, m_white_is_bot, m_black_is_bot,
+                               whiteThinkMs, whiteDepth, blackThinkMs,
+                               blackDepth);
 
       sf::Clock clock;
-      while (window.isOpen() && gameController.getNextAction() ==
-                                    lilia::controller::GameController::NextAction::None) {
+      while (window.isOpen() &&
+             gameController.getNextAction() ==
+                 lilia::controller::GameController::NextAction::None) {
         float deltaSeconds = clock.restart().asSeconds();
         sf::Event event;
         while (window.pollEvent(event)) {
-          if (event.type == sf::Event::Closed) window.close();
+          if (event.type == sf::Event::Closed)
+            window.close();
           gameController.handleEvent(event);
         }
         gameController.update(deltaSeconds);
-        drawVerticalGradient(window, sf::Color{24, 29, 38}, sf::Color{16, 19, 26});
+        drawVerticalGradient(window, sf::Color{24, 29, 38},
+                             sf::Color{16, 19, 26});
         gameController.render();
         window.display();
       }
 
-      if (!window.isOpen()) return 0;
+      if (!window.isOpen())
+        return 0;
 
       action = gameController.getNextAction();
 
-    } while (action == lilia::controller::GameController::NextAction::Rematch && window.isOpen());
+    } while (action == lilia::controller::GameController::NextAction::Rematch &&
+             window.isOpen());
 
-    if (action != lilia::controller::GameController::NextAction::NewBot) break;
+    if (action != lilia::controller::GameController::NextAction::NewBot)
+      break;
   }
 
   return 0;
 }
 
-}  // namespace lilia::app
+} // namespace lilia::app

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -20,52 +20,58 @@
 namespace lilia::controller {
 
 namespace {
-inline bool isValid(core::Square sq) {
-  return sq != core::NO_SQUARE;
-}
-}  // namespace
+inline bool isValid(core::Square sq) { return sq != core::NO_SQUARE; }
+} // namespace
 
 GameController::GameController(view::GameView &gView, model::ChessGame &game)
     : m_game_view(gView), m_chess_game(game) {
-  m_input_manager.setOnClick([this](core::MousePos pos) { this->onClick(pos); });
+  m_input_manager.setOnClick(
+      [this](core::MousePos pos) { this->onClick(pos); });
   m_input_manager.setOnDrag(
-      [this](core::MousePos start, core::MousePos current) { this->onDrag(start, current); });
-  m_input_manager.setOnDrop(
-      [this](core::MousePos start, core::MousePos end) { this->onDrop(start, end); });
+      [this](core::MousePos start, core::MousePos current) {
+        this->onDrag(start, current);
+      });
+  m_input_manager.setOnDrop([this](core::MousePos start, core::MousePos end) {
+    this->onDrop(start, end);
+  });
 
   m_sound_manager.loadSounds();
 
   m_game_manager = std::make_unique<GameManager>(game);
   BotPlayer::setEvalCallback([this](int eval) { m_eval_cp.store(eval); });
 
-  m_game_manager->setOnMoveExecuted([this](const model::Move &mv, bool isPlayerMove, bool onClick) {
-    // If the user is currently viewing an older position, jump back to
-    // the latest board state before applying the new move to avoid
-    // corrupting the displayed board.
-    if (this->m_fen_index != this->m_fen_history.size() - 1) {
-      this->m_fen_index = this->m_fen_history.size() - 1;
-      this->m_game_view.setBoardFen(this->m_fen_history[this->m_fen_index]);
-      this->m_game_view.selectMove(this->m_fen_index ? this->m_fen_index - 1
-                                                     : static_cast<std::size_t>(-1));
-      this->m_game_view.clearAllHighlights();
-      if (!this->m_move_history.empty()) {
-        const MoveView &info = this->m_move_history.back();
-        this->m_last_move_squares = {info.move.from, info.move.to};
-        this->highlightLastMove();
-      }
-    }
+  m_game_manager->setOnMoveExecuted(
+      [this](const model::Move &mv, bool isPlayerMove, bool onClick) {
+        // If the user is currently viewing an older position, jump back to
+        // the latest board state before applying the new move to avoid
+        // corrupting the displayed board.
+        if (this->m_fen_index != this->m_fen_history.size() - 1) {
+          this->m_fen_index = this->m_fen_history.size() - 1;
+          this->m_game_view.setBoardFen(this->m_fen_history[this->m_fen_index]);
+          this->m_game_view.selectMove(this->m_fen_index
+                                           ? this->m_fen_index - 1
+                                           : static_cast<std::size_t>(-1));
+          this->m_game_view.clearAllHighlights();
+          if (!this->m_move_history.empty()) {
+            const MoveView &info = this->m_move_history.back();
+            this->m_last_move_squares = {info.move.from, info.move.to};
+            this->highlightLastMove();
+          }
+        }
 
-    this->movePieceAndClear(mv, isPlayerMove, onClick);
-    this->m_chess_game.checkGameResult();
-    this->m_game_view.addMove(move_to_uci(mv));
-    this->m_fen_history.push_back(this->m_chess_game.getFen());
-    this->m_fen_index = this->m_fen_history.size() - 1;
-    this->m_game_view.selectMove(this->m_fen_index ? this->m_fen_index - 1
-                                                   : static_cast<std::size_t>(-1));
-  });
+        this->movePieceAndClear(mv, isPlayerMove, onClick);
+        this->m_chess_game.checkGameResult();
+        this->m_game_view.addMove(move_to_uci(mv));
+        this->m_fen_history.push_back(this->m_chess_game.getFen());
+        this->m_fen_index = this->m_fen_history.size() - 1;
+        this->m_game_view.selectMove(this->m_fen_index
+                                         ? this->m_fen_index - 1
+                                         : static_cast<std::size_t>(-1));
+      });
 
   m_game_manager->setOnPromotionRequested([this](core::Square sq) {
-    this->m_game_view.playPromotionSelectAnim(sq, m_chess_game.getGameState().sideToMove);
+    this->m_game_view.playPromotionSelectAnim(
+        sq, m_chess_game.getGameState().sideToMove);
   });
 
   m_game_manager->setOnGameEnd([this](core::GameResult res) {
@@ -75,15 +81,18 @@ GameController::GameController(view::GameView &gView, model::ChessGame &game)
 
 GameController::~GameController() = default;
 
-void GameController::startGame(const std::string &fen, bool whiteIsBot, bool blackIsBot,
-                               int think_time_ms, int depth) {
+void GameController::startGame(const std::string &fen, bool whiteIsBot,
+                               bool blackIsBot, int whiteThinkTimeMs,
+                               int whiteDepth, int blackThinkTimeMs,
+                               int blackDepth) {
   m_sound_manager.playEffect(view::sound::Effect::GameBegins);
   m_game_view.hideResignPopup();
   m_game_view.hideGameOverPopup();
   m_game_view.setGameOver(false);
   m_game_view.init(fen);
   m_game_view.setBotMode(whiteIsBot || blackIsBot);
-  m_game_manager->startGame(fen, whiteIsBot, blackIsBot, think_time_ms, depth);
+  m_game_manager->startGame(fen, whiteIsBot, blackIsBot, whiteThinkTimeMs,
+                            whiteDepth, blackThinkTimeMs, blackDepth);
 
   m_fen_history.clear();
   m_fen_history.push_back(fen);
@@ -114,7 +123,8 @@ void GameController::startGame(const std::string &fen, bool whiteIsBot, bool bla
 }
 
 void GameController::handleEvent(const sf::Event &event) {
-  if (event.type == sf::Event::MouseButtonPressed && event.mouseButton.button == sf::Mouse::Left) {
+  if (event.type == sf::Event::MouseButtonPressed &&
+      event.mouseButton.button == sf::Mouse::Left) {
     core::MousePos mp(event.mouseButton.x, event.mouseButton.y);
 
     if (m_game_view.isResignPopupOpen()) {
@@ -141,30 +151,30 @@ void GameController::handleEvent(const sf::Event &event) {
 
     auto opt = m_game_view.getOptionAt(mp);
     switch (opt) {
-      case view::MoveListView::Option::Resign:
-        m_game_view.showResignPopup();
-        return;
-      case view::MoveListView::Option::Prev:
-        stepBackward();
-        return;
-      case view::MoveListView::Option::Next:
-        stepForward();
-        return;
-      case view::MoveListView::Option::Settings:
-        // Settings logic placeholder
-        return;
-      case view::MoveListView::Option::NewBot:
-        m_next_action = NextAction::NewBot;
-        return;
-      case view::MoveListView::Option::Rematch:
-        m_next_action = NextAction::Rematch;
-        return;
-      default:
-        break;
+    case view::MoveListView::Option::Resign:
+      m_game_view.showResignPopup();
+      return;
+    case view::MoveListView::Option::Prev:
+      stepBackward();
+      return;
+    case view::MoveListView::Option::Next:
+      stepForward();
+      return;
+    case view::MoveListView::Option::Settings:
+      // Settings logic placeholder
+      return;
+    case view::MoveListView::Option::NewBot:
+      m_next_action = NextAction::NewBot;
+      return;
+    case view::MoveListView::Option::Rematch:
+      m_next_action = NextAction::Rematch;
+      return;
+    default:
+      break;
     }
 
-    std::size_t idx =
-        m_game_view.getMoveIndexAt(core::MousePos(event.mouseButton.x, event.mouseButton.y));
+    std::size_t idx = m_game_view.getMoveIndexAt(
+        core::MousePos(event.mouseButton.x, event.mouseButton.y));
     if (idx != static_cast<std::size_t>(-1)) {
       m_fen_index = idx + 1;
       m_game_view.setBoardFen(m_fen_history[m_fen_index]);
@@ -180,7 +190,8 @@ void GameController::handleEvent(const sf::Event &event) {
 
   if (event.type == sf::Event::MouseWheelScrolled) {
     m_game_view.scrollMoveList(event.mouseWheelScroll.delta);
-    if (m_fen_index != m_fen_history.size() - 1) return;
+    if (m_fen_index != m_fen_history.size() - 1)
+      return;
   }
 
   if (event.type == sf::Event::KeyPressed) {
@@ -192,24 +203,26 @@ void GameController::handleEvent(const sf::Event &event) {
       return;
     }
   }
-  if (m_fen_index != m_fen_history.size() - 1) return;
+  if (m_fen_index != m_fen_history.size() - 1)
+    return;
 
-  if (m_chess_game.getResult() != core::GameResult::ONGOING) return;
+  if (m_chess_game.getResult() != core::GameResult::ONGOING)
+    return;
 
   switch (event.type) {
-    case sf::Event::MouseMoved:
-      onMouseMove(core::MousePos(event.mouseMove.x, event.mouseMove.y));
-      break;
-    case sf::Event::MouseButtonPressed:
-      if (event.mouseButton.button == sf::Mouse::Left)
-        onMousePressed(core::MousePos(event.mouseButton.x, event.mouseButton.y));
-      break;
-    case sf::Event::MouseButtonReleased:
-      if (event.mouseButton.button == sf::Mouse::Left)
-        onMouseReleased(core::MousePos(event.mouseButton.x, event.mouseButton.y));
-      break;
-    default:
-      break;
+  case sf::Event::MouseMoved:
+    onMouseMove(core::MousePos(event.mouseMove.x, event.mouseMove.y));
+    break;
+  case sf::Event::MouseButtonPressed:
+    if (event.mouseButton.button == sf::Mouse::Left)
+      onMousePressed(core::MousePos(event.mouseButton.x, event.mouseButton.y));
+    break;
+  case sf::Event::MouseButtonReleased:
+    if (event.mouseButton.button == sf::Mouse::Left)
+      onMouseReleased(core::MousePos(event.mouseButton.x, event.mouseButton.y));
+    break;
+  default:
+    break;
   }
   m_input_manager.processEvent(event);
 }
@@ -243,15 +256,18 @@ void GameController::onMousePressed(core::MousePos pos) {
   m_selection_changed_on_press = false;
 
   // Neue Interaktion verwirft angezeigte Premoves
-  if (m_premove_from != core::NO_SQUARE) clearPremove();
+  if (m_premove_from != core::NO_SQUARE)
+    clearPremove();
 
   if (m_game_view.hasPieceOnSquare(sq)) {
-    if (!tryMove(m_selected_sq, sq)) m_game_view.setHandClosedCursor();
+    if (!tryMove(m_selected_sq, sq))
+      m_game_view.setHandClosedCursor();
   } else {
     m_game_view.setDefaultCursor();
   }
 
-  if (!m_game_view.hasPieceOnSquare(sq)) return;
+  if (!m_game_view.hasPieceOnSquare(sq))
+    return;
 
   const bool selectionWasDifferent = (m_selected_sq != sq);
 
@@ -264,7 +280,8 @@ void GameController::onMousePressed(core::MousePos pos) {
       highlightLastMove();
       selectSquare(sq);
       hoverSquare(sq);
-      if (isHumanPiece(sq)) showAttacks(getAttackSquares(sq));
+      if (isHumanPiece(sq))
+        showAttacks(getAttackSquares(sq));
     }
   } else {
     m_preview_active = false;
@@ -274,7 +291,8 @@ void GameController::onMousePressed(core::MousePos pos) {
     highlightLastMove();
     selectSquare(sq);
     hoverSquare(sq);
-    if (isHumanPiece(sq)) showAttacks(getAttackSquares(sq));
+    if (isHumanPiece(sq))
+      showAttacks(getAttackSquares(sq));
   }
 
   if (!tryMove(m_selected_sq, sq)) {
@@ -301,27 +319,29 @@ void GameController::onMouseReleased(core::MousePos pos) {
   onMouseMove(pos);
 }
 
-void GameController::render() {
-  m_game_view.render();
-}
+void GameController::render() { m_game_view.render(); }
 
 void GameController::update(float dt) {
   // Always tick UI/animations/particles, even after game end
   m_game_view.update(dt);
   m_game_view.updateEval(m_eval_cp.load());
 
-  // Stop here if the game is over (no engine/user logic), but keep animating the view
-  if (m_chess_game.getResult() != core::GameResult::ONGOING) return;
+  // Stop here if the game is over (no engine/user logic), but keep animating
+  // the view
+  if (m_chess_game.getResult() != core::GameResult::ONGOING)
+    return;
 
   // Game logic continues only while ongoing
-  if (m_game_manager) m_game_manager->update(dt);
+  if (m_game_manager)
+    m_game_manager->update(dt);
 
   // Safe auto-move (premove) handling
   if (m_has_pending_auto_move) {
     const auto st = m_chess_game.getGameState();
     if (m_game_manager && m_game_manager->isHuman(st.sideToMove) &&
         hasCurrentLegalMove(m_pending_from, m_pending_to)) {
-      (void)m_game_manager->requestUserMove(m_pending_from, m_pending_to, /*onClick*/ true);
+      (void)m_game_manager->requestUserMove(m_pending_from, m_pending_to,
+                                            /*onClick*/ true);
     }
     m_has_pending_auto_move = false;
     m_pending_from = m_pending_to = core::NO_SQUARE;
@@ -329,8 +349,10 @@ void GameController::update(float dt) {
 }
 
 void GameController::highlightLastMove() {
-  if (isValid(m_last_move_squares.first)) m_game_view.highlightSquare(m_last_move_squares.first);
-  if (isValid(m_last_move_squares.second)) m_game_view.highlightSquare(m_last_move_squares.second);
+  if (isValid(m_last_move_squares.first))
+    m_game_view.highlightSquare(m_last_move_squares.first);
+  if (isValid(m_last_move_squares.second))
+    m_game_view.highlightSquare(m_last_move_squares.second);
 }
 
 void GameController::selectSquare(core::Square sq) {
@@ -357,7 +379,8 @@ void GameController::hoverSquare(core::Square sq) {
 }
 
 void GameController::dehoverSquare() {
-  if (isValid(m_hover_sq)) m_game_view.clearHighlightHoverSquare(m_hover_sq);
+  if (isValid(m_hover_sq))
+    m_game_view.clearHighlightHoverSquare(m_hover_sq);
   m_hover_sq = core::NO_SQUARE;
 }
 
@@ -371,7 +394,8 @@ void GameController::clearPremove() {
 }
 
 // --------- ZENTRALE Move-Callback-Behandlung (auch Engine-Züge) ----------
-void GameController::movePieceAndClear(const model::Move &move, bool isPlayerMove, bool onClick) {
+void GameController::movePieceAndClear(const model::Move &move,
+                                       bool isPlayerMove, bool onClick) {
   const core::Square from = move.from;
   const core::Square to = move.to;
 
@@ -396,8 +420,9 @@ void GameController::movePieceAndClear(const model::Move &move, bool isPlayerMov
   core::Square epVictimSq = core::NO_SQUARE;
   const core::Color moverColorBefore = ~m_chess_game.getGameState().sideToMove;
   if (move.isEnPassant) {
-    epVictimSq = (moverColorBefore == core::Color::White) ? static_cast<core::Square>(to - 8)
-                                                          : static_cast<core::Square>(to + 8);
+    epVictimSq = (moverColorBefore == core::Color::White)
+                     ? static_cast<core::Square>(to - 8)
+                     : static_cast<core::Square>(to + 8);
   }
 
   core::PieceType capturedType = core::PieceType::None;
@@ -426,7 +451,8 @@ void GameController::movePieceAndClear(const model::Move &move, bool isPlayerMov
   clearLastMoveHighlight();
   m_last_move_squares = {from, to};
   highlightLastMove();
-  if (isValid(m_selected_sq)) m_game_view.highlightSquare(m_selected_sq);
+  if (isValid(m_selected_sq))
+    m_game_view.highlightSquare(m_selected_sq);
 
   const core::Color sideToMoveNow = m_chess_game.getGameState().sideToMove;
 
@@ -440,7 +466,8 @@ void GameController::movePieceAndClear(const model::Move &move, bool isPlayerMov
   } else if (move.castle != model::CastleSide::None) {
     effect = view::sound::Effect::Castle;
   } else {
-    effect = isPlayerMove ? view::sound::Effect::PlayerMove : view::sound::Effect::EnemyMove;
+    effect = isPlayerMove ? view::sound::Effect::PlayerMove
+                          : view::sound::Effect::EnemyMove;
   }
 
   m_sound_manager.playEffect(effect);
@@ -475,16 +502,19 @@ void GameController::snapAndReturn(core::Square sq, core::MousePos cur) {
 
 [[nodiscard]] bool GameController::tryMove(core::Square a, core::Square b) {
   // Nur Züge für menschlich kontrollierte Figuren in Betracht ziehen
-  if (!isHumanPiece(a)) return false;
+  if (!isHumanPiece(a))
+    return false;
   for (auto att : getAttackSquares(a)) {
-    if (att == b) return true;
+    if (att == b)
+      return true;
   }
   return false;
 }
 
 [[nodiscard]] bool GameController::isPromotion(core::Square a, core::Square b) {
   for (const auto &m : m_chess_game.generateLegalMoves()) {
-    if (m.from == a && m.to == b && m.promotion != core::PieceType::None) return true;
+    if (m.from == a && m.to == b && m.promotion != core::PieceType::None)
+      return true;
   }
   return false;
 }
@@ -493,13 +523,15 @@ void GameController::snapAndReturn(core::Square sq, core::MousePos cur) {
   return m_game_view.isSameColorPiece(a, b);
 }
 
-[[nodiscard]] std::vector<core::Square> GameController::getAttackSquares(
-    core::Square pieceSQ) const {
+[[nodiscard]] std::vector<core::Square>
+GameController::getAttackSquares(core::Square pieceSQ) const {
   std::vector<core::Square> att;
-  if (!isValid(pieceSQ)) return att;
+  if (!isValid(pieceSQ))
+    return att;
 
   auto pc = m_chess_game.getPiece(pieceSQ);
-  if (pc.type == core::PieceType::None) return att;
+  if (pc.type == core::PieceType::None)
+    return att;
 
   // Visualisierung immer aus Sicht der Figurenfarbe – unabhängig vom Zugrecht.
   model::Position pos = m_chess_game.getPositionRefForBot();
@@ -511,7 +543,8 @@ void GameController::snapAndReturn(core::Square sq, core::MousePos cur) {
   gen.generatePseudoLegalMoves(pos.getBoard(), st, pseudo);
 
   for (const auto &m : pseudo) {
-    if (m.from == pieceSQ) att.push_back(m.to);
+    if (m.from == pieceSQ)
+      att.push_back(m.to);
   }
   return att;
 }
@@ -545,9 +578,11 @@ void GameController::onClick(core::MousePos mousePos) {
 
   // Promotion-Auswahl?
   if (m_game_view.isInPromotionSelection()) {
-    const core::PieceType promoType = m_game_view.getSelectedPromotion(mousePos);
+    const core::PieceType promoType =
+        m_game_view.getSelectedPromotion(mousePos);
     m_game_view.removePromotionSelection();
-    if (m_game_manager) m_game_manager->completePendingPromotion(promoType);
+    if (m_game_manager)
+      m_game_manager->completePendingPromotion(promoType);
     deselectSquare();
     return;
   }
@@ -555,8 +590,9 @@ void GameController::onClick(core::MousePos mousePos) {
   // Bereits etwas selektiert? -> erst Zug versuchen (hat Vorrang)
   if (m_selected_sq != core::NO_SQUARE) {
     const auto st = m_chess_game.getGameState();
-    const bool ownTurnAndPiece = (st.sideToMove == m_chess_game.getPiece(m_selected_sq).color) &&
-                                 (!m_game_manager || m_game_manager->isHuman(st.sideToMove));
+    const bool ownTurnAndPiece =
+        (st.sideToMove == m_chess_game.getPiece(m_selected_sq).color) &&
+        (!m_game_manager || m_game_manager->isHuman(st.sideToMove));
     const core::Color humanColor = ~st.sideToMove;
 
     if (tryMove(m_selected_sq, sq)) {
@@ -579,7 +615,7 @@ void GameController::onClick(core::MousePos mousePos) {
           m_game_view.highlightAttackSquare(sq);
       }
       m_selected_sq = core::NO_SQUARE;
-      return;  // NICHT umselektieren
+      return; // NICHT umselektieren
     }
 
     // Kein legaler Klick-Zug -> ggf. Auswahl ändern/entfernen
@@ -590,7 +626,8 @@ void GameController::onClick(core::MousePos mousePos) {
         m_game_view.clearAllHighlights();
         highlightLastMove();
         selectSquare(sq);
-        if (isHumanPiece(sq)) showAttacks(getAttackSquares(sq));
+        if (isHumanPiece(sq))
+          showAttacks(getAttackSquares(sq));
       }
     } else {
       deselectSquare();
@@ -603,7 +640,8 @@ void GameController::onClick(core::MousePos mousePos) {
     m_game_view.clearAllHighlights();
     highlightLastMove();
     selectSquare(sq);
-    if (isHumanPiece(sq)) showAttacks(getAttackSquares(sq));
+    if (isHumanPiece(sq))
+      showAttacks(getAttackSquares(sq));
   }
 }
 
@@ -612,19 +650,24 @@ void GameController::onDrag(core::MousePos start, core::MousePos current) {
   const core::MousePos clamped = m_game_view.clampPosToBoard(current);
   const core::Square sqMous = m_game_view.mousePosToSquare(clamped);
 
-  if (m_game_view.isInPromotionSelection()) return;
-  if (!m_game_view.hasPieceOnSquare(sqStart)) return;
-  if (!m_dragging) return;
+  if (m_game_view.isInPromotionSelection())
+    return;
+  if (!m_game_view.hasPieceOnSquare(sqStart))
+    return;
+  if (!m_dragging)
+    return;
 
   // Sicherstellen, dass die Startfigur selektiert ist
   if (m_selected_sq != sqStart) {
     m_game_view.clearAllHighlights();
     highlightLastMove();
     selectSquare(sqStart);
-    if (isHumanPiece(sqStart)) showAttacks(getAttackSquares(sqStart));
+    if (isHumanPiece(sqStart))
+      showAttacks(getAttackSquares(sqStart));
   }
 
-  if (m_hover_sq != sqMous) dehoverSquare();
+  if (m_hover_sq != sqMous)
+    dehoverSquare();
   hoverSquare(sqMous);
 
   m_game_view.setPieceToMouseScreenPos(sqStart, current);
@@ -633,11 +676,13 @@ void GameController::onDrag(core::MousePos start, core::MousePos current) {
 
 void GameController::onDrop(core::MousePos start, core::MousePos end) {
   const core::Square from = m_game_view.mousePosToSquare(start);
-  const core::Square to = m_game_view.mousePosToSquare(m_game_view.clampPosToBoard(end));
+  const core::Square to =
+      m_game_view.mousePosToSquare(m_game_view.clampPosToBoard(end));
 
   dehoverSquare();
 
-  if (m_game_view.isInPromotionSelection()) return;
+  if (m_game_view.isInPromotionSelection())
+    return;
 
   if (!m_game_view.hasPieceOnSquare(from)) {
     deselectSquare();
@@ -654,10 +699,12 @@ void GameController::onDrop(core::MousePos start, core::MousePos end) {
 
   const auto st = m_chess_game.getGameState();
   const core::Color fromColor = m_chess_game.getPiece(from).color;
-  const bool humanTurnNow = (m_game_manager && m_game_manager->isHuman(st.sideToMove));
+  const bool humanTurnNow =
+      (m_game_manager && m_game_manager->isHuman(st.sideToMove));
   const bool movingOwnTurnPiece = humanTurnNow && (fromColor == st.sideToMove);
   const core::Color humanNextColor = ~st.sideToMove;
-  const bool humanNextIsHuman = (!m_game_manager || m_game_manager->isHuman(humanNextColor));
+  const bool humanNextIsHuman =
+      (!m_game_manager || m_game_manager->isHuman(humanNextColor));
 
   if (from != to && tryMove(from, to)) {
     if (movingOwnTurnPiece) {
@@ -685,10 +732,12 @@ void GameController::onDrop(core::MousePos start, core::MousePos end) {
 
     if (!setPremove) {
       // Fehlversuch -> zurückschnappen + evtl. Warnung
-      if (m_chess_game.isKingInCheck(m_chess_game.getGameState().sideToMove) && m_game_manager &&
-          m_game_manager->isHuman(m_chess_game.getGameState().sideToMove) && from != to &&
-          m_game_view.hasPieceOnSquare(from) &&
-          m_chess_game.getPiece(from).color == m_chess_game.getGameState().sideToMove) {
+      if (m_chess_game.isKingInCheck(m_chess_game.getGameState().sideToMove) &&
+          m_game_manager &&
+          m_game_manager->isHuman(m_chess_game.getGameState().sideToMove) &&
+          from != to && m_game_view.hasPieceOnSquare(from) &&
+          m_chess_game.getPiece(from).color ==
+              m_chess_game.getGameState().sideToMove) {
         m_game_view.warningKingSquareAnim(
             m_chess_game.getKingSquare(m_chess_game.getGameState().sideToMove));
         m_sound_manager.playEffect(view::sound::Effect::Warning);
@@ -707,7 +756,8 @@ void GameController::onDrop(core::MousePos start, core::MousePos end) {
         m_game_view.clearAllHighlights();
         highlightLastMove();
         selectSquare(from);
-        if (isHumanPiece(from)) showAttacks(getAttackSquares(from));
+        if (isHumanPiece(from))
+          showAttacks(getAttackSquares(from));
       }
     } else {
       // Bei Premove keine Snap-Animation – wir zeigen bereits die
@@ -724,53 +774,61 @@ void GameController::onDrop(core::MousePos start, core::MousePos end) {
 /* -------------------- Hilfsfunktionen -------------------- */
 
 bool GameController::isHumanPiece(core::Square sq) const {
-  if (!isValid(sq)) return false;
+  if (!isValid(sq))
+    return false;
   auto pc = m_chess_game.getPiece(sq);
-  if (pc.type == core::PieceType::None) return false;
+  if (pc.type == core::PieceType::None)
+    return false;
   return (!m_game_manager) ? true : m_game_manager->isHuman(pc.color);
 }
 
-bool GameController::hasCurrentLegalMove(core::Square from, core::Square to) const {
-  if (!isValid(from) || !isValid(to)) return false;
+bool GameController::hasCurrentLegalMove(core::Square from,
+                                         core::Square to) const {
+  if (!isValid(from) || !isValid(to))
+    return false;
   // Muss zur Seite gehören, die am Zug ist
   const auto st = m_chess_game.getGameState();
   auto pc = m_chess_game.getPiece(from);
-  if (pc.type == core::PieceType::None || pc.color != st.sideToMove) return false;
+  if (pc.type == core::PieceType::None || pc.color != st.sideToMove)
+    return false;
 
   for (const auto &m : m_chess_game.generateLegalMoves()) {
-    if (m.from == from && m.to == to) return true;
+    if (m.from == from && m.to == to)
+      return true;
   }
   return false;
 }
 
-void GameController::showGameOver(core::GameResult res, core::Color sideToMove) {
+void GameController::showGameOver(core::GameResult res,
+                                  core::Color sideToMove) {
   m_sound_manager.playEffect(view::sound::Effect::GameEnds);
   std::string resultStr;
   switch (res) {
-    case core::GameResult::CHECKMATE:
-      resultStr = (sideToMove == core::Color::White) ? "0-1" : "1-0";
-      m_game_view.showGameOverPopup(sideToMove == core::Color::White ? "Black won" : "White won");
-      break;
-    case core::GameResult::REPETITION:
-      resultStr = "1/2-1/2";
-      m_game_view.showGameOverPopup("Draw by repetition");
-      break;
-    case core::GameResult::MOVERULE:
-      resultStr = "1/2-1/2";
-      m_game_view.showGameOverPopup("Draw by 50 move rule");
-      break;
-    case core::GameResult::STALEMATE:
-      resultStr = "1/2-1/2";
-      m_game_view.showGameOverPopup("Stalemate");
-      break;
-    case core::GameResult::INSUFFICIENT:
-      resultStr = "1/2-1/2";
-      m_game_view.showGameOverPopup("Insufficient material");
-      break;
-    default:
-      resultStr = "error";
-      m_game_view.showGameOverPopup("result is not correct");
-      break;
+  case core::GameResult::CHECKMATE:
+    resultStr = (sideToMove == core::Color::White) ? "0-1" : "1-0";
+    m_game_view.showGameOverPopup(
+        sideToMove == core::Color::White ? "Black won" : "White won");
+    break;
+  case core::GameResult::REPETITION:
+    resultStr = "1/2-1/2";
+    m_game_view.showGameOverPopup("Draw by repetition");
+    break;
+  case core::GameResult::MOVERULE:
+    resultStr = "1/2-1/2";
+    m_game_view.showGameOverPopup("Draw by 50 move rule");
+    break;
+  case core::GameResult::STALEMATE:
+    resultStr = "1/2-1/2";
+    m_game_view.showGameOverPopup("Stalemate");
+    break;
+  case core::GameResult::INSUFFICIENT:
+    resultStr = "1/2-1/2";
+    m_game_view.showGameOverPopup("Insufficient material");
+    break;
+  default:
+    resultStr = "error";
+    m_game_view.showGameOverPopup("result is not correct");
+    break;
   }
   m_game_view.addResult(resultStr);
   m_game_view.setGameOver(true);
@@ -790,24 +848,28 @@ void GameController::stepBackward() {
         info.move.to, info.move.from, core::NO_SQUARE, core::PieceType::None,
         [this, info, epVictim]() {
           if (info.move.isCapture) {
-            core::Square capSq = info.move.isEnPassant ? epVictim : info.move.to;
+            core::Square capSq =
+                info.move.isEnPassant ? epVictim : info.move.to;
             m_game_view.addPiece(info.capturedType, ~info.moverColor, capSq);
           }
           if (info.move.promotion != core::PieceType::None) {
             m_game_view.removePiece(info.move.from);
-            m_game_view.addPiece(core::PieceType::Pawn, info.moverColor, info.move.from);
+            m_game_view.addPiece(core::PieceType::Pawn, info.moverColor,
+                                 info.move.from);
           }
         });
     if (info.move.castle != model::CastleSide::None) {
-      const core::Square rookFrom =
-          m_chess_game.getRookSquareFromCastleside(info.move.castle, info.moverColor);
-      const core::Square rookTo = (info.move.castle == model::CastleSide::KingSide)
-                                      ? static_cast<core::Square>(info.move.to - 1)
-                                      : static_cast<core::Square>(info.move.to + 1);
+      const core::Square rookFrom = m_chess_game.getRookSquareFromCastleside(
+          info.move.castle, info.moverColor);
+      const core::Square rookTo =
+          (info.move.castle == model::CastleSide::KingSide)
+              ? static_cast<core::Square>(info.move.to - 1)
+              : static_cast<core::Square>(info.move.to + 1);
       m_game_view.animationMovePiece(rookTo, rookFrom);
     }
     --m_fen_index;
-    m_game_view.selectMove(m_fen_index ? m_fen_index - 1 : static_cast<std::size_t>(-1));
+    m_game_view.selectMove(m_fen_index ? m_fen_index - 1
+                                       : static_cast<std::size_t>(-1));
     m_last_move_squares = {info.move.from, info.move.to};
     m_game_view.clearAllHighlights();
     highlightLastMove();
@@ -829,16 +891,19 @@ void GameController::stepForward() {
       m_game_view.removePiece(info.move.to);
     }
     if (info.move.castle != model::CastleSide::None) {
-      const core::Square rookFrom =
-          m_chess_game.getRookSquareFromCastleside(info.move.castle, info.moverColor);
-      const core::Square rookTo = (info.move.castle == model::CastleSide::KingSide)
-                                      ? static_cast<core::Square>(info.move.to - 1)
-                                      : static_cast<core::Square>(info.move.to + 1);
+      const core::Square rookFrom = m_chess_game.getRookSquareFromCastleside(
+          info.move.castle, info.moverColor);
+      const core::Square rookTo =
+          (info.move.castle == model::CastleSide::KingSide)
+              ? static_cast<core::Square>(info.move.to - 1)
+              : static_cast<core::Square>(info.move.to + 1);
       m_game_view.animationMovePiece(rookFrom, rookTo);
     }
-    m_game_view.animationMovePiece(info.move.from, info.move.to, epVictim, info.move.promotion);
+    m_game_view.animationMovePiece(info.move.from, info.move.to, epVictim,
+                                   info.move.promotion);
     ++m_fen_index;
-    m_game_view.selectMove(m_fen_index ? m_fen_index - 1 : static_cast<std::size_t>(-1));
+    m_game_view.selectMove(m_fen_index ? m_fen_index - 1
+                                       : static_cast<std::size_t>(-1));
     m_last_move_squares = {info.move.from, info.move.to};
     m_game_view.clearAllHighlights();
     highlightLastMove();
@@ -849,11 +914,12 @@ void GameController::stepForward() {
 void GameController::resign() {
   m_game_manager->stopGame();
   m_chess_game.setResult(core::GameResult::CHECKMATE);
-  showGameOver(core::GameResult::CHECKMATE, m_chess_game.getGameState().sideToMove);
+  showGameOver(core::GameResult::CHECKMATE,
+               m_chess_game.getGameState().sideToMove);
 }
 
 GameController::NextAction GameController::getNextAction() const {
   return m_next_action;
 }
 
-}  // namespace lilia::controller
+} // namespace lilia::controller

--- a/src/lilia/controller/game_manager.cpp
+++ b/src/lilia/controller/game_manager.cpp
@@ -8,26 +8,26 @@
 
 namespace lilia::controller {
 
-GameManager::GameManager(model::ChessGame& model) : m_game(model) {}
+GameManager::GameManager(model::ChessGame &model) : m_game(model) {}
 
-GameManager::~GameManager() {
-  stopGame();
-}
+GameManager::~GameManager() { stopGame(); }
 
-void GameManager::startGame(const std::string& fen, bool whiteIsBot, bool blackIsBot,
-                            int thinkTimeMs, int depth) {
+void GameManager::startGame(const std::string &fen, bool whiteIsBot,
+                            bool blackIsBot, int whiteThinkTimeMs,
+                            int whiteDepth, int blackThinkTimeMs,
+                            int blackDepth) {
   std::lock_guard lock(m_mutex);
   m_game.setPosition(fen);
   m_cancel_bot.store(false);
   m_waiting_promotion = false;
 
   if (whiteIsBot)
-    m_white_player = std::make_unique<BotPlayer>(thinkTimeMs, depth);
+    m_white_player = std::make_unique<BotPlayer>(whiteThinkTimeMs, whiteDepth);
   else
     m_white_player.reset();
 
   if (blackIsBot)
-    m_black_player = std::make_unique<BotPlayer>(thinkTimeMs, depth);
+    m_black_player = std::make_unique<BotPlayer>(blackThinkTimeMs, blackDepth);
   else
     m_black_player.reset();
 
@@ -55,20 +55,24 @@ void GameManager::update([[maybe_unused]] float dt) {
   }
 }
 
-bool GameManager::requestUserMove(core::Square from, core::Square to, bool onClick) {
+bool GameManager::requestUserMove(core::Square from, core::Square to,
+                                  bool onClick) {
   std::lock_guard lock(m_mutex);
-  if (m_waiting_promotion) return false;  // waiting on previous promotion
-  if (!isHuman(m_game.getGameState().sideToMove)) return false;
+  if (m_waiting_promotion)
+    return false; // waiting on previous promotion
+  if (!isHuman(m_game.getGameState().sideToMove))
+    return false;
 
-  const auto& moves = m_game.generateLegalMoves();
-  for (const auto& m : moves) {
+  const auto &moves = m_game.generateLegalMoves();
+  for (const auto &m : moves) {
     if (m.from == from && m.to == to) {
       if (m.promotion != core::PieceType::None) {
         // request UI promotion selection
         m_waiting_promotion = true;
         m_promotion_from = from;
         m_promotion_to = to;
-        if (onPromotionRequested_) onPromotionRequested_(to);
+        if (onPromotionRequested_)
+          onPromotionRequested_(to);
         return false;
       }
 
@@ -83,11 +87,13 @@ bool GameManager::requestUserMove(core::Square from, core::Square to, bool onCli
 
 void GameManager::completePendingPromotion(core::PieceType promotion) {
   std::lock_guard lock(m_mutex);
-  if (!m_waiting_promotion) return;
+  if (!m_waiting_promotion)
+    return;
 
-  const auto& moves = m_game.generateLegalMoves();
-  for (const auto& m : moves) {
-    if (m.from == m_promotion_from && m.to == m_promotion_to && m.promotion == promotion) {
+  const auto &moves = m_game.generateLegalMoves();
+  for (const auto &m : moves) {
+    if (m.from == m_promotion_from && m.to == m_promotion_to &&
+        m.promotion == promotion) {
       applyMoveAndNotify(m, true);
       m_waiting_promotion = false;
       startBotIfNeeded();
@@ -95,21 +101,24 @@ void GameManager::completePendingPromotion(core::PieceType promotion) {
     }
   }
 
-  // if we reach here, the promotion selection did not match available moves -> cancel
+  // if we reach here, the promotion selection did not match available moves ->
+  // cancel
   m_waiting_promotion = false;
 }
 
-void GameManager::applyMoveAndNotify(const model::Move& mv, bool onClick) {
+void GameManager::applyMoveAndNotify(const model::Move &mv, bool onClick) {
   const core::Color mover = m_game.getGameState().sideToMove;
   m_game.doMove(mv.from, mv.to, mv.promotion);
 
   bool wasPlayerMove = isHuman(mover);
 
-  if (onMoveExecuted_) onMoveExecuted_(mv, wasPlayerMove, onClick);
+  if (onMoveExecuted_)
+    onMoveExecuted_(mv, wasPlayerMove, onClick);
 
   auto result = m_game.getResult();
   if (result != core::GameResult::ONGOING) {
-    if (onGameEnd_) onGameEnd_(result);
+    if (onGameEnd_)
+      onGameEnd_(result);
     // cancel any running bot
     m_cancel_bot.store(true);
   }
@@ -117,7 +126,7 @@ void GameManager::applyMoveAndNotify(const model::Move& mv, bool onClick) {
 
 void GameManager::startBotIfNeeded() {
   core::Color stm = m_game.getGameState().sideToMove;
-  IPlayer* p = nullptr;
+  IPlayer *p = nullptr;
   if (stm == core::Color::White)
     p = m_white_player.get();
   else
@@ -134,7 +143,8 @@ void GameManager::startBotIfNeeded() {
   }
 }
 
-void GameManager::setBotForColor(core::Color color, std::unique_ptr<IPlayer> bot) {
+void GameManager::setBotForColor(core::Color color,
+                                 std::unique_ptr<IPlayer> bot) {
   std::lock_guard lock(m_mutex);
   if (color == core::Color::White)
     m_white_player = std::move(bot);
@@ -143,7 +153,8 @@ void GameManager::setBotForColor(core::Color color, std::unique_ptr<IPlayer> bot
 }
 
 bool GameManager::isHuman(core::Color color) const {
-  const IPlayer* p = (color == core::Color::White) ? m_white_player.get() : m_black_player.get();
+  const IPlayer *p = (color == core::Color::White) ? m_white_player.get()
+                                                   : m_black_player.get();
   return !p || p->isHuman();
 }
 
@@ -151,4 +162,4 @@ bool GameManager::isHumanTurn() const {
   return isHuman(m_game.getGameState().sideToMove);
 }
 
-}  // namespace lilia::controller
+} // namespace lilia::controller


### PR DESCRIPTION
## Summary
- Pass per-color bot configuration (think time and depth) from the start screen through the app and controller layers
- Update GameManager and GameController to handle separate bot settings for white and black

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68b4cb6dcfd88329af440e967b0f80d1