### PR TITLE
Enable post-game board flipping with custom icon

### DIFF
--- a/include/lilia/view/board_view.hpp
+++ b/include/lilia/view/board_view.hpp
@@ -27,7 +27,8 @@ public:
 
 private:
   Board m_board;
-  Entity m_flip_icon;
+  Entity::Position m_flip_pos{};
+  float m_flip_size{0.f};
   bool m_flipped{false};
 };
 

--- a/include/lilia/view/render_constants.hpp
+++ b/include/lilia/view/render_constants.hpp
@@ -53,7 +53,6 @@ const std::string STR_TEXTURE_HISTORY_OVERLAY = "historyOverlay";
 const std::string STR_FILE_PATH_HAND_OPEN = "assets/icons/cursor_hand_open.png";
 const std::string STR_FILE_PATH_HAND_CLOSED = "assets/icons/cursor_hand_closed.png";
 const std::string STR_FILE_PATH_FONT = "assets/font/OpenSans-Regular.ttf";
-const std::string STR_FILE_PATH_FLIP = "assets/icons/flip.png";
 const std::string STR_FILE_PATH_ICON_LILIA = "assets/icons/lilia.png";
 const std::string STR_FILE_PATH_ICON_LILIA_START_SCREEN = "assets/icons/lilia_transparent.png";
 const std::string STR_FILE_PATH_ICON_CHALLENGER = "assets/icons/challenger.png";

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -220,8 +220,16 @@ void GameController::handleEvent(const sf::Event &event) {
   if (m_fen_index != m_fen_history.size() - 1)
     return;
 
-  if (m_chess_game.getResult() != core::GameResult::ONGOING)
+  if (m_chess_game.getResult() != core::GameResult::ONGOING) {
+    if (event.type == sf::Event::MouseButtonPressed &&
+        event.mouseButton.button == sf::Mouse::Left) {
+      core::MousePos mp(event.mouseButton.x, event.mouseButton.y);
+      if (m_game_view.isOnFlipIcon(mp)) {
+        m_game_view.toggleBoardOrientation();
+      }
+    }
     return;
+  }
 
   switch (event.type) {
   case sf::Event::MouseMoved:


### PR DESCRIPTION
## Summary
- Allow side swapping even after the game concludes by handling flip clicks when the result is final.
- Replace texture-based flip button with a procedurally drawn, hover-aware icon.

## Testing
- `cmake .. && make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68b4d3bf69388329af8df37ae2abbc22