### PR TITLE
Add toggleable eval bar button

### DIFF
--- a/include/lilia/view/eval_bar.hpp
+++ b/include/lilia/view/eval_bar.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include "entity.hpp"
 #include <SFML/Graphics/Text.hpp>
+#include <SFML/Graphics/Rect.hpp>
+#include "../controller/mousepos.hpp"
 #include <string>
 
 namespace sf {
@@ -19,12 +21,18 @@ class EvalBar : Entity {
   void setResult(const std::string &result);
   void reset();
 
+  void toggleVisibility();
+  [[nodiscard]] bool isOnToggle(core::MousePos mousePos) const;
+
  private:
   void scaleToEval(float e);
   Entity m_black_background;
   Entity m_white_fill_eval;
   sf::Font m_font;
   sf::Text m_score_text;
+  sf::Text m_toggle_text;
+  sf::FloatRect m_toggle_bounds;
+  bool m_visible{true};
   float m_display_eval{0.f};
   float m_target_eval{0.f};
   bool m_has_result{false};

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/Graphics/Font.hpp>
+#include <SFML/Graphics/Text.hpp>
+#include <SFML/Graphics/Rect.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <SFML/Window/Cursor.hpp>
 #include <functional>
@@ -108,6 +111,9 @@ class GameView {
   void toggleBoardOrientation();
   [[nodiscard]] bool isOnFlipIcon(core::MousePos mousePos) const;
 
+  void toggleEvalBarVisibility();
+  [[nodiscard]] bool isOnEvalToggle(core::MousePos mousePos) const;
+
  private:
   void layout(unsigned int width, unsigned int height);
 
@@ -133,6 +139,12 @@ class GameView {
 
   // FX
   ParticleSystem m_particles;
+
+  // eval bar toggle button
+  bool m_show_eval_bar;
+  sf::Font m_ui_font;
+  sf::Text m_eval_toggle_text;
+  sf::FloatRect m_eval_toggle_bounds;
 };
 
 }  // namespace lilia::view

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
 #include <SFML/Graphics/RenderWindow.hpp>
-#include <SFML/Graphics/Font.hpp>
-#include <SFML/Graphics/Text.hpp>
-#include <SFML/Graphics/Rect.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <SFML/Window/Cursor.hpp>
 #include <functional>
@@ -140,11 +137,7 @@ class GameView {
   // FX
   ParticleSystem m_particles;
 
-  // eval bar toggle button
-  bool m_show_eval_bar;
-  sf::Font m_ui_font;
-  sf::Text m_eval_toggle_text;
-  sf::FloatRect m_eval_toggle_bounds;
+  // eval bar toggle handled internally by EvalBar
 };
 
 }  // namespace lilia::view

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -158,6 +158,11 @@ void GameController::handleEvent(const sf::Event &event) {
       return;
     }
 
+    if (m_game_view.isOnEvalToggle(mp)) {
+      m_game_view.toggleEvalBarVisibility();
+      return;
+    }
+
     auto opt = m_game_view.getOptionAt(mp);
     switch (opt) {
     case view::MoveListView::Option::Resign:


### PR DESCRIPTION
## Summary
- add hoverable Hide/Show button beneath evaluation bar
- support toggling eval bar visibility with new GameView APIs

## Testing
- `cmake -S . -B build` *(pass)*
- `cmake --build build` *(fail: undefined X11 references)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d8ca2f3c832986520756853bcc12