### PR TITLE
Add captured pieces box to player info

### DIFF
--- a/include/lilia/view/player_info_view.hpp
+++ b/include/lilia/view/player_info_view.hpp
@@ -14,9 +14,10 @@ namespace lilia::view {
 
 class PlayerInfoView {
  public:
-  PlayerInfoView();
+ PlayerInfoView();
 
   void setInfo(const PlayerInfo& info);
+  void setPlayerColor(core::Color color);
   void setPositionClamped(const Entity::Position& pos, const sf::Vector2u& viewportSize);
   void render(sf::RenderWindow& window);
 
@@ -32,6 +33,9 @@ class PlayerInfoView {
   sf::Font m_font2;
   sf::Text m_name;
   sf::Text m_elo;
+  sf::RectangleShape m_captureBox;
+  sf::Text m_noCaptures;
+  core::Color m_playerColor{core::Color::White};
   Entity::Position m_position{};
   std::vector<Entity> m_capturedPieces;
 

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -46,6 +46,8 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
 
   m_top_player.setInfo(topInfo);
   m_bottom_player.setInfo(bottomInfo);
+  m_top_player.setPlayerColor(core::Color::Black);
+  m_bottom_player.setPlayerColor(core::Color::White);
 
   // board orientation
   m_board_view.setFlipped(bottomIsBot && !topIsBot);


### PR DESCRIPTION
## Summary
- Show captured pieces inside a themed rectangle box with dynamic sizing and "no captures" placeholder.
- Allow PlayerInfoView to theme capture box by player color and update rendering logic.
- Set player colors in GameView to configure capture boxes.

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b4e054631c8329a0ff90f7e357c8f7