### PR TITLE
Fix captured pieces orientation and board flip behavior

### DIFF
--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -137,6 +137,8 @@ class GameView {
   MoveListView m_move_list;
   PlayerInfoView m_top_player;
   PlayerInfoView m_bottom_player;
+  PlayerInfoView* m_white_player{};
+  PlayerInfoView* m_black_player{};
   ModalView m_modal;  // ← replaces ad-hoc popup fields
 
   // FX

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -49,6 +49,8 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
   m_bottom_player.setInfo(bottomInfo);
   m_top_player.setPlayerColor(core::Color::Black);
   m_bottom_player.setPlayerColor(core::Color::White);
+  m_black_player = &m_top_player;
+  m_white_player = &m_bottom_player;
 
   // board orientation
   m_board_view.setFlipped(bottomIsBot && !topIsBot);
@@ -254,6 +256,9 @@ Entity::Position GameView::getPieceSize(core::Square pos) const {
 
 void GameView::toggleBoardOrientation() {
   m_board_view.toggleFlipped();
+  std::swap(m_top_player, m_bottom_player);
+  std::swap(m_white_player, m_black_player);
+  layout(m_window.getSize().x, m_window.getSize().y);
 }
 
 bool GameView::isOnFlipIcon(core::MousePos mousePos) const {
@@ -292,14 +297,14 @@ void GameView::removePiece(core::Square pos) {
 }
 
 void GameView::addCapturedPiece(core::Color capturer, core::PieceType type) {
-  PlayerInfoView& view = (capturer == core::Color::White) ? m_bottom_player
-                                                         : m_top_player;
+  PlayerInfoView& view =
+      (capturer == core::Color::White) ? *m_white_player : *m_black_player;
   view.addCapturedPiece(type, ~capturer);
 }
 
 void GameView::removeCapturedPiece(core::Color capturer) {
-  PlayerInfoView& view = (capturer == core::Color::White) ? m_bottom_player
-                                                         : m_top_player;
+  PlayerInfoView& view =
+      (capturer == core::Color::White) ? *m_white_player : *m_black_player;
   view.removeCapturedPiece();
 }
 

--- a/src/lilia/view/player_info_view.cpp
+++ b/src/lilia/view/player_info_view.cpp
@@ -69,11 +69,11 @@ PlayerInfoView::PlayerInfoView() {
 void PlayerInfoView::setPlayerColor(core::Color color) {
   m_playerColor = color;
   if (m_playerColor == core::Color::White) {
-    m_captureBox.setFillColor(kBoxDark);
-    m_noCaptures.setFillColor(kEloColor);
-  } else {
     m_captureBox.setFillColor(kBoxLight);
     m_noCaptures.setFillColor(kFrameFill);
+  } else {
+    m_captureBox.setFillColor(kBoxDark);
+    m_noCaptures.setFillColor(kEloColor);
   }
 }
 
@@ -212,7 +212,6 @@ void PlayerInfoView::layoutCaptured() {
   // Scale each piece to fit capH with padding, then place them L→R with slight overlap
   const float targetH = capH - 2.f * kCapPad;
   float x = kCapPad;
-  float maxH = 0.f;
 
   for (auto& piece : m_capturedPieces) {
     const auto orig = piece.getOriginalSize();
@@ -224,10 +223,10 @@ void PlayerInfoView::layoutCaptured() {
     const float w = orig.x * s;
     const float h = orig.y * s;
 
-    piece.setPosition(snap({baseX * 1.04f + x, baseY * 1.7f + kCapPad}));
+    const float px = baseX + x;
+    const float py = baseY + (capH - h) * 0.5f;
+    piece.setPosition(snap({px, py}));
     x += w * kPieceAdvance;  // advance slightly less than full width to tuck them
-
-    maxH = std::max(maxH, h);
   }
 
   // Right padding so last piece isn't flush


### PR DESCRIPTION
## Summary
- Show captured pieces for both sides by correcting capture box colors and layout
- Flip player info and captured pieces when the board orientation toggles

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e99b09448329ac5bebe66332843b