### PR TITLE
Fix eval bar not updating after game over navigation

### DIFF
--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -116,6 +116,9 @@ class GameView {
   void toggleEvalBarVisibility();
   [[nodiscard]] bool isOnEvalToggle(core::MousePos mousePos) const;
 
+  void resetEvalBar();
+  void setEvalResult(const std::string &result);
+
  private:
   void layout(unsigned int width, unsigned int height);
 

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -271,6 +271,12 @@ bool GameView::isOnEvalToggle(core::MousePos mousePos) const {
   return m_eval_bar.isOnToggle(mousePos);
 }
 
+void GameView::resetEvalBar() { m_eval_bar.reset(); }
+
+void GameView::setEvalResult(const std::string &result) {
+  m_eval_bar.setResult(result);
+}
+
 // ---------- Pieces / Highlights ----------
 bool GameView::hasPieceOnSquare(core::Square pos) const {
   return m_piece_manager.hasPieceOnSquare(pos);


### PR DESCRIPTION
## Summary
- allow GameController to reset and reapply eval bar result when stepping through move list after a game ends
- expose GameView helpers to clear and set eval bar state
- derive game result strings in controller to restore final evaluation display

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY OPENGL_INCLUDE_DIR))*

------
https://chatgpt.com/codex/tasks/task_e_68b4f3e7e074832992979773d049d722