### PR TITLE
Allow board flip when reviewing moves

### DIFF
--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -179,6 +179,11 @@ void GameController::handleEvent(const sf::Event &event) {
       return;
     }
 
+    if (m_game_view.isOnFlipIcon(mp)) {
+      m_game_view.toggleBoardOrientation();
+      return;
+    }
+
     auto opt = m_game_view.getOptionAt(mp);
     switch (opt) {
     case view::MoveListView::Option::Resign:


### PR DESCRIPTION
## Summary
- Always handle board flip icon before ignoring board interactions when viewing past moves

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f613e2408329a36abcc06e26f4a1