### PR TITLE
Highlight active chess clock with overlay and icon

### DIFF
--- a/include/lilia/controller/time_controller.hpp
+++ b/include/lilia/controller/time_controller.hpp
@@ -15,6 +15,7 @@ class TimeController {
 
   [[nodiscard]] float getTime(core::Color color) const;
   [[nodiscard]] std::optional<core::Color> getFlagged() const;
+  [[nodiscard]] std::optional<core::Color> getActive() const;
 
  private:
   float m_white_time;

--- a/include/lilia/view/clock.hpp
+++ b/include/lilia/view/clock.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <SFML/Graphics/CircleShape.hpp>
 #include <SFML/Graphics/RectangleShape.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/Graphics/Text.hpp>
@@ -16,6 +17,7 @@ class Clock {
   void setPlayerColor(core::Color color);
   void setPosition(const sf::Vector2f& pos);
   void setTime(float seconds);
+  void setActive(bool active);
   void render(sf::RenderWindow& window);
 
   static constexpr float WIDTH = 120.f;
@@ -23,8 +25,12 @@ class Clock {
 
  private:
   sf::RectangleShape m_box;
+  sf::RectangleShape m_overlay;
   sf::Text m_text;
   sf::Font m_font;
+  bool m_active{false};
+  sf::CircleShape m_icon_circle;
+  sf::RectangleShape m_icon_hand;
 };
 
 }  // namespace lilia::view

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -5,6 +5,7 @@
 #include <SFML/Window/Cursor.hpp>
 #include <functional>
 #include <vector>
+#include <optional>
 
 #include "../chess_types.hpp"
 #include "../constants.hpp"
@@ -121,6 +122,7 @@ class GameView {
   void setEvalResult(const std::string &result);
 
   void updateClock(core::Color color, float seconds);
+  void setClockActive(std::optional<core::Color> active);
 
  private:
   void layout(unsigned int width, unsigned int height);

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -416,6 +416,7 @@ void GameController::update(float dt) {
                             m_time_controller->getTime(core::Color::White));
     m_game_view.updateClock(core::Color::Black,
                             m_time_controller->getTime(core::Color::Black));
+    m_game_view.setClockActive(m_time_controller->getActive());
     if (auto flag = m_time_controller->getFlagged()) {
       m_chess_game.setResult(core::GameResult::TIMEOUT);
       if (m_game_manager)

--- a/src/lilia/controller/time_controller.cpp
+++ b/src/lilia/controller/time_controller.cpp
@@ -40,5 +40,9 @@ float TimeController::getTime(core::Color color) const {
 
 std::optional<core::Color> TimeController::getFlagged() const { return m_flagged; }
 
+std::optional<core::Color> TimeController::getActive() const {
+  return m_running ? std::optional<core::Color>(m_active) : std::nullopt;
+}
+
 }  // namespace lilia::controller
 

--- a/src/lilia/view/clock.cpp
+++ b/src/lilia/view/clock.cpp
@@ -22,6 +22,8 @@ const sf::Color kLightText(210, 224, 255);  // text on dark bg
 constexpr float kScale = 0.80f;  // 20% smaller
 constexpr float kPadX = 10.f;
 constexpr float kPadY = 6.f;
+constexpr float kIconRadius = 6.f;
+constexpr float kIconOffsetX = kIconRadius + 2.f;  // keep a small left margin
 
 inline float snapf(float v) {
   return std::round(v);
@@ -51,8 +53,21 @@ Clock::Clock() {
   const float baseH = HEIGHT * kScale;
 
   m_box.setSize({baseW, baseH});
-  m_box.setOutlineThickness(1.f);
+  m_box.setOutlineThickness(2.f);
   m_box.setOutlineColor(kOutline);
+
+  m_overlay.setSize({baseW, baseH});
+  m_overlay.setFillColor(sf::Color(0, 0, 0, 100));
+
+  m_icon_circle.setRadius(kIconRadius);
+  m_icon_circle.setOrigin(kIconRadius, kIconRadius);
+  m_icon_circle.setFillColor(sf::Color::Transparent);
+  m_icon_circle.setOutlineThickness(1.f);
+  m_icon_circle.setOutlineColor(kOutline);
+  m_icon_hand.setSize({kIconRadius - 2.f, 1.f});
+  m_icon_hand.setFillColor(kOutline);
+  m_icon_hand.setOrigin(0.f, 0.5f);
+  m_icon_hand.setRotation(-90.f);
 
   m_font.loadFromFile(constant::STR_FILE_PATH_FONT);
   m_font.setSmooth(false);
@@ -75,6 +90,7 @@ void Clock::setPlayerColor(core::Color color) {
 void Clock::setPosition(const sf::Vector2f& pos) {
   // position the box
   m_box.setPosition({snapf(pos.x), snapf(pos.y)});
+  m_overlay.setPosition(m_box.getPosition());
 
   // right-align the time inside the box (like chess.com)
   const auto tb = m_text.getLocalBounds();  // tb.top is usually negative in SFML
@@ -84,6 +100,11 @@ void Clock::setPosition(const sf::Vector2f& pos) {
   const float ty = m_box.getPosition().y + (bs.y - tb.height) * 0.5f - tb.top;
 
   m_text.setPosition({snapf(tx), snapf(ty)});
+
+  const float iconX = m_box.getPosition().x + kIconOffsetX;
+  const float iconY = m_box.getPosition().y + bs.y * 0.5f;
+  m_icon_circle.setPosition({snapf(iconX), snapf(iconY)});
+  m_icon_hand.setPosition({snapf(iconX), snapf(iconY)});
 }
 
 void Clock::setTime(float seconds) {
@@ -99,17 +120,33 @@ void Clock::setTime(float seconds) {
   if (needW > size.x) {
     size.x = needW;
     m_box.setSize(size);
+    m_overlay.setSize(size);
   } else if (size.x < minW) {
     size.x = minW;
     m_box.setSize(size);
+    m_overlay.setSize(size);
   }
 
   // reposition text for right-alignment with the (possibly) new width
   setPosition(m_box.getPosition());
 }
 
+void Clock::setActive(bool active) {
+  m_active = active;
+  if (active) {
+    m_overlay.setFillColor(sf::Color(255, 255, 255, 40));
+  } else {
+    m_overlay.setFillColor(sf::Color(0, 0, 0, 100));
+  }
+}
+
 void Clock::render(sf::RenderWindow& window) {
   window.draw(m_box);
+  window.draw(m_overlay);
+  if (m_active) {
+    window.draw(m_icon_circle);
+    window.draw(m_icon_hand);
+  }
   window.draw(m_text);
 }
 

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -297,6 +297,13 @@ void GameView::updateClock(core::Color color, float seconds) {
   clk.setTime(seconds);
 }
 
+void GameView::setClockActive(std::optional<core::Color> active) {
+  if (m_white_clock)
+    m_white_clock->setActive(active && *active == core::Color::White);
+  if (m_black_clock)
+    m_black_clock->setActive(active && *active == core::Color::Black);
+}
+
 // ---------- Pieces / Highlights ----------
 bool GameView::hasPieceOnSquare(core::Square pos) const {
   return m_piece_manager.hasPieceOnSquare(pos);


### PR DESCRIPTION
## Summary
- Visually distinguish the active clock with a light overlay and clock icon, while idle clocks retain a dark overlay and clearer outline
- Allow GameView to toggle clock highlighting and expose active side through TimeController
- Update GameController to forward active clock state to the view

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL, UDev, OpenAL, VORBIS, FLAC; after installing dependencies, build ultimately fails with missing X11 references)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fecadc448329b9664fa3bfd10857