### PR TITLE
Add time toggle for game clocks

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -65,7 +65,8 @@ public:
                  bool whiteIsBot = false, bool blackIsBot = true,
                  int whiteThinkTimeMs = 1000, int whiteDepth = 5,
                  int blackThinkTimeMs = 1000, int blackDepth = 5,
-                 int baseSeconds = 0, int incrementSeconds = 0);
+                 bool useTimer = true, int baseSeconds = 0,
+                 int incrementSeconds = 0);
 
   enum class NextAction { None, NewBot, Rematch };
   [[nodiscard]] NextAction getNextAction() const;

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -123,6 +123,7 @@ class GameView {
 
   void updateClock(core::Color color, float seconds);
   void setClockActive(std::optional<core::Color> active);
+  void setClocksVisible(bool visible);
 
  private:
   void layout(unsigned int width, unsigned int height);
@@ -151,6 +152,7 @@ class GameView {
   Clock m_bottom_clock;
   Clock* m_white_clock{};
   Clock* m_black_clock{};
+  bool m_show_clocks{true};
   ModalView m_modal;  // ← replaces ad-hoc popup fields
 
   // FX

--- a/include/lilia/view/start_screen.hpp
+++ b/include/lilia/view/start_screen.hpp
@@ -18,6 +18,7 @@ struct StartConfig {
   std::string fen{core::START_FEN};
   int timeBaseSeconds{300};     // default 5 minutes
   int timeIncrementSeconds{0};  // default 0s increment
+  bool timeEnabled{true};       // whether clocks are used
 };
 
 struct BotOption {
@@ -80,8 +81,11 @@ class StartScreen {
   // time control state
   int m_baseSeconds{300};
   int m_incrementSeconds{0};
+  bool m_timeEnabled{true};
 
   // time control UI
+  sf::RectangleShape m_timeToggleBtn;
+  sf::Text m_timeToggleText;
   sf::RectangleShape m_timePanel;
   sf::Text m_timeTitle;
   sf::Text m_timeMain;  // "HH:MM:SS"
@@ -113,6 +117,7 @@ class StartScreen {
   bool handleMouse(sf::Vector2f pos, StartConfig &cfg);
   bool handleFenMouse(sf::Vector2f pos, StartConfig &cfg);
   bool isValidFen(const std::string &fen);
+  void updateTimeToggle();
   void processHoldRepeater(HoldRepeater &r, const sf::FloatRect &bounds, sf::Vector2f mouse,
                            std::function<void()> stepFn, float initialDelay = 0.35f,
                            float repeatRate = 0.06f);

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -43,6 +43,7 @@ int App::run() {
     std::string m_start_fen = cfg.fen;
     int baseSeconds = cfg.timeBaseSeconds;
     int incrementSeconds = cfg.timeIncrementSeconds;
+    bool timeEnabled = cfg.timeEnabled;
 
     auto whiteCfg = getBotConfig(cfg.whiteBot);
     auto blackCfg = getBotConfig(cfg.blackBot);
@@ -62,7 +63,8 @@ int App::run() {
 
       gameController.startGame(m_start_fen, m_white_is_bot, m_black_is_bot,
                                whiteThinkMs, whiteDepth, blackThinkMs,
-                               blackDepth, baseSeconds, incrementSeconds);
+                               blackDepth, timeEnabled, baseSeconds,
+                               incrementSeconds);
 
       sf::Clock clock;
       while (window.isOpen() &&

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -111,7 +111,7 @@ GameController::~GameController() = default;
 void GameController::startGame(const std::string &fen, bool whiteIsBot,
                                bool blackIsBot, int whiteThinkTimeMs,
                                int whiteDepth, int blackThinkTimeMs,
-                               int blackDepth, int baseSeconds,
+                               int blackDepth, bool useTimer, int baseSeconds,
                                int incrementSeconds) {
   m_sound_manager.playEffect(view::sound::Effect::GameBegins);
   m_game_view.hideResignPopup();
@@ -122,12 +122,18 @@ void GameController::startGame(const std::string &fen, bool whiteIsBot,
   m_game_manager->startGame(fen, whiteIsBot, blackIsBot, whiteThinkTimeMs,
                             whiteDepth, blackThinkTimeMs, blackDepth);
 
-  m_time_controller =
-      std::make_unique<TimeController>(baseSeconds, incrementSeconds);
-  core::Color stm = m_chess_game.getGameState().sideToMove;
-  m_time_controller->start(stm);
-  m_game_view.updateClock(core::Color::White, static_cast<float>(baseSeconds));
-  m_game_view.updateClock(core::Color::Black, static_cast<float>(baseSeconds));
+  if (useTimer) {
+    m_time_controller =
+        std::make_unique<TimeController>(baseSeconds, incrementSeconds);
+    core::Color stm = m_chess_game.getGameState().sideToMove;
+    m_time_controller->start(stm);
+    m_game_view.setClocksVisible(true);
+    m_game_view.updateClock(core::Color::White, static_cast<float>(baseSeconds));
+    m_game_view.updateClock(core::Color::Black, static_cast<float>(baseSeconds));
+  } else {
+    m_time_controller.reset();
+    m_game_view.setClocksVisible(false);
+  }
 
   m_fen_history.clear();
   m_eval_history.clear();

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -99,8 +99,10 @@ void GameView::render() {
   m_piece_manager.renderPieces(m_window, m_chess_animator);
   m_highlight_manager.renderAttack(m_window);
   m_chess_animator.render(m_window);
-  m_top_clock.render(m_window);
-  m_bottom_clock.render(m_window);
+  if (m_show_clocks) {
+    m_top_clock.render(m_window);
+    m_bottom_clock.render(m_window);
+  }
 
   // right stack
   m_move_list.render(m_window);
@@ -302,6 +304,10 @@ void GameView::setClockActive(std::optional<core::Color> active) {
     m_white_clock->setActive(active && *active == core::Color::White);
   if (m_black_clock)
     m_black_clock->setActive(active && *active == core::Color::Black);
+}
+
+void GameView::setClocksVisible(bool visible) {
+  m_show_clocks = visible;
 }
 
 // ---------- Pieces / Highlights ----------


### PR DESCRIPTION
## Summary
- Add "Time On/Off" toggle above start screen clock with accent for enabled and red-purple when disabled
- Hide clocks and skip timing logic when time is disabled
- Pass time toggle through configuration and game controller

## Testing
- `cmake -S . -B build` *(passes after installing dependencies)*
- `cmake --build build` *(fails: undefined X11 references)*

------
https://chatgpt.com/codex/tasks/task_e_68b502fb3ea88329b6c85cabf817222d