### PR TITLE
feat: improve premove highlighting

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <deque>
 
 // Forward declaration to avoid heavy SFML header
 namespace sf {
@@ -34,6 +35,13 @@ struct MoveView {
   core::PieceType capturedType;
   view::sound::Effect sound;
   int evalCp{};
+};
+
+struct Premove {
+  core::Square from;
+  core::Square to;
+  core::PieceType capturedType;
+  core::Color capturedColor;
 };
 
 class GameController {
@@ -89,6 +97,8 @@ private:
   void hoverSquare(core::Square sq);
   void dehoverSquare();
   void clearPremove();
+  void enqueuePremove(core::Square from, core::Square to);
+  void restorePremoves();
 
   void movePieceAndClear(const model::Move &move, bool isPlayerMove,
                          bool onClick);
@@ -128,10 +138,11 @@ private:
   core::Square m_prev_selected_before_preview = core::NO_SQUARE;
   bool m_selection_changed_on_press = false;
 
-  core::Square m_premove_from = core::NO_SQUARE;
-  core::Square m_premove_to = core::NO_SQUARE;
+  std::deque<Premove> m_premove_queue;
   core::Square m_pending_from = core::NO_SQUARE;
   core::Square m_pending_to = core::NO_SQUARE;
+  core::PieceType m_pending_capture_type = core::PieceType::None;
+  bool m_skip_next_move_animation = false;
 
   core::Square m_selected_sq = core::NO_SQUARE; ///< Currently selected square.
   core::Square m_hover_sq = core::NO_SQUARE;    ///< Currently hovered square.

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -67,6 +67,8 @@ class GameView {
                                                Entity::Position pieceSize = {0.f, 0.f}) const;
   void setPieceToMouseScreenPos(core::Square pos, core::MousePos mousePos);
   void setPieceToSquareScreenPos(core::Square from, core::Square to);
+  void movePiece(core::Square from, core::Square to,
+                 core::PieceType promotion = core::PieceType::None);
 
   [[nodiscard]] sf::Vector2u getWindowSize() const;
   [[nodiscard]] Entity::Position getPieceSize(core::Square pos) const;
@@ -87,8 +89,11 @@ class GameView {
   void highlightAttackSquare(core::Square pos);
   void highlightCaptureSquare(core::Square pos);
   void highlightHoverSquare(core::Square pos);
+  void highlightPremoveSquare(core::Square pos);
   void clearHighlightSquare(core::Square pos);
   void clearHighlightHoverSquare(core::Square pos);
+  void clearHighlightPremoveSquare(core::Square pos);
+  void clearPremoveHighlights();
   void clearAllHighlights();
 
   void warningKingSquareAnim(core::Square ksq);

--- a/include/lilia/view/highlight_manager.hpp
+++ b/include/lilia/view/highlight_manager.hpp
@@ -15,13 +15,17 @@ class HighlightManager {
   void highlightAttackSquare(core::Square pos);
   void highlightCaptureSquare(core::Square pos);
   void highlightHoverSquare(core::Square pos);
+  void highlightPremoveSquare(core::Square pos);
   void clearAllHighlights();
   void clearHighlightSquare(core::Square pos);
   void clearHighlightHoverSquare(core::Square pos);
+  void clearHighlightPremoveSquare(core::Square pos);
+  void clearPremoveHighlights();
 
   void renderAttack(sf::RenderWindow& window);
   void renderHover(sf::RenderWindow& window);
   void renderSelect(sf::RenderWindow& window);
+  void renderPremove(sf::RenderWindow& window);
 
  private:
   void renderEntitiesToBoard(std::unordered_map<core::Square, Entity>& map,
@@ -32,6 +36,7 @@ class HighlightManager {
   std::unordered_map<core::Square, Entity> m_hl_attack_squares;
   std::unordered_map<core::Square, Entity> m_hl_select_squares;
   std::unordered_map<core::Square, Entity> m_hl_hover_squares;
+  std::unordered_map<core::Square, Entity> m_hl_premove_squares;
 };
 
 }  // namespace lilia::view

--- a/include/lilia/view/render_constants.hpp
+++ b/include/lilia/view/render_constants.hpp
@@ -47,6 +47,7 @@ const std::string STR_TEXTURE_SELECTHLIGHT = "selectHighlight";
 const std::string STR_TEXTURE_ATTACKHLIGHT = "attackHighlight";
 const std::string STR_TEXTURE_CAPTUREHLIGHT = "captureHighlight";
 const std::string STR_TEXTURE_HOVERHLIGHT = "hoverHighlight";
+const std::string STR_TEXTURE_PREMOVEHLIGHT = "premoveHighlight";
 const std::string STR_TEXTURE_WARNINGHLIGHT = "warningHighlight";
 const std::string STR_TEXTURE_HISTORY_OVERLAY = "historyOverlay";
 

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -94,6 +94,7 @@ void GameView::render() {
   m_top_player.render(m_window);
   m_bottom_player.render(m_window);
   m_highlight_manager.renderSelect(m_window);
+  m_highlight_manager.renderPremove(m_window);
   m_chess_animator.renderHighlightLevel(m_window);
   m_highlight_manager.renderHover(m_window);
   m_piece_manager.renderPieces(m_window, m_chess_animator);
@@ -245,6 +246,10 @@ void GameView::setPieceToSquareScreenPos(core::Square from, core::Square to) {
   m_piece_manager.setPieceToSquareScreenPos(from, to);
 }
 
+void GameView::movePiece(core::Square from, core::Square to, core::PieceType promotion) {
+  m_piece_manager.movePiece(from, to, promotion);
+}
+
 // ---------- Cursors ----------
 void GameView::setDefaultCursor() {
   m_window.setMouseCursor(m_cursor_default);
@@ -360,12 +365,21 @@ void GameView::highlightAttackSquare(core::Square pos) {
 void GameView::highlightCaptureSquare(core::Square pos) {
   m_highlight_manager.highlightCaptureSquare(pos);
 }
+void GameView::highlightPremoveSquare(core::Square pos) {
+  m_highlight_manager.highlightPremoveSquare(pos);
+}
 
 void GameView::clearHighlightSquare(core::Square pos) {
   m_highlight_manager.clearHighlightSquare(pos);
 }
 void GameView::clearHighlightHoverSquare(core::Square pos) {
   m_highlight_manager.clearHighlightHoverSquare(pos);
+}
+void GameView::clearHighlightPremoveSquare(core::Square pos) {
+  m_highlight_manager.clearHighlightPremoveSquare(pos);
+}
+void GameView::clearPremoveHighlights() {
+  m_highlight_manager.clearPremoveHighlights();
 }
 void GameView::clearAllHighlights() {
   m_highlight_manager.clearAllHighlights();

--- a/src/lilia/view/highlight_manager.cpp
+++ b/src/lilia/view/highlight_manager.cpp
@@ -30,6 +30,9 @@ void HighlightManager::renderHover(sf::RenderWindow& window) {
 void HighlightManager::renderSelect(sf::RenderWindow& window) {
   renderEntitiesToBoard(m_hl_select_squares, window);
 }
+void HighlightManager::renderPremove(sf::RenderWindow& window) {
+  renderEntitiesToBoard(m_hl_premove_squares, window);
+}
 
 void HighlightManager::highlightSquare(core::Square pos) {
   Entity newSelectHlight(TextureTable::getInstance().get(constant::STR_TEXTURE_SELECTHLIGHT));
@@ -49,16 +52,28 @@ void HighlightManager::highlightHoverSquare(core::Square pos) {
   Entity newHoverHlight(TextureTable::getInstance().get(constant::STR_TEXTURE_HOVERHLIGHT));
   m_hl_hover_squares[pos] = std::move(newHoverHlight);
 }
+void HighlightManager::highlightPremoveSquare(core::Square pos) {
+  Entity newPremove(TextureTable::getInstance().get(constant::STR_TEXTURE_PREMOVEHLIGHT));
+  newPremove.setScale(constant::SQUARE_PX_SIZE, constant::SQUARE_PX_SIZE);
+  m_hl_premove_squares[pos] = std::move(newPremove);
+}
 void HighlightManager::clearAllHighlights() {
   m_hl_select_squares.clear();
   m_hl_attack_squares.clear();
   m_hl_hover_squares.clear();
+  m_hl_premove_squares.clear();
 }
 void HighlightManager::clearHighlightSquare(core::Square pos) {
   m_hl_select_squares.erase(pos);
 }
 void HighlightManager::clearHighlightHoverSquare(core::Square pos) {
   m_hl_hover_squares.erase(pos);
+}
+void HighlightManager::clearHighlightPremoveSquare(core::Square pos) {
+  m_hl_premove_squares.erase(pos);
+}
+void HighlightManager::clearPremoveHighlights() {
+  m_hl_premove_squares.clear();
 }
 
 }  // namespace lilia::view

--- a/src/lilia/view/texture_table.cpp
+++ b/src/lilia/view/texture_table.cpp
@@ -422,6 +422,8 @@ void TextureTable::preLoad() {
   // Overlays
   load(constant::STR_TEXTURE_SELECTHLIGHT,
        sf::Color(100, 190, 255, 170));  // #64BEFF, matches accent
+  load(constant::STR_TEXTURE_PREMOVEHLIGHT,
+       sf::Color(180, 120, 255, 160));  // purple-ish premove highlight
   load(constant::STR_TEXTURE_WARNINGHLIGHT,
        sf::Color(255, 102, 102, 190));  // #FF6666, clear check alert
   load(constant::STR_TEXTURE_HISTORY_OVERLAY,


### PR DESCRIPTION
## Summary
- add dedicated premove highlight texture and rendering support
- queue multiple premoves with visual piece placement and restoration
- move pieces instantly for premove previews and manage highlights

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL / UDev / OpenAL / VORBIS / FLAC initially; after installing deps, build fails with numerous undefined X11 references)*
- `cmake --build build` *(fails: undefined references to X11 functions in sfml-window)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e8ffbe448329ac610447e1e8ab6c