### PR TITLE
Fix player color assignment and improve premove handling

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -102,7 +102,7 @@ private:
   void dehoverSquare();
   void clearPremove();
   void enqueuePremove(core::Square from, core::Square to);
-  void restorePremoves();
+  [[nodiscard]] bool isPseudoLegalPremove(core::Square from, core::Square to) const;
 
   void movePieceAndClear(const model::Move &move, bool isPlayerMove,
                          bool onClick);

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -47,19 +47,33 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
       bottomIsBot ? getBotConfig(BotType::Lilia).info
                   : PlayerInfo{"Challenger", 0, constant::STR_FILE_PATH_ICON_CHALLENGER};
 
-  m_top_player.setInfo(topInfo);
-  m_bottom_player.setInfo(bottomInfo);
-  m_top_player.setPlayerColor(core::Color::Black);
-  m_bottom_player.setPlayerColor(core::Color::White);
-  m_black_player = &m_top_player;
-  m_white_player = &m_bottom_player;
-  m_top_clock.setPlayerColor(core::Color::Black);
-  m_bottom_clock.setPlayerColor(core::Color::White);
-  m_black_clock = &m_top_clock;
-  m_white_clock = &m_bottom_clock;
+  bool flipped = bottomIsBot && !topIsBot;
+  if (flipped) {
+    m_top_player.setInfo(bottomInfo);
+    m_bottom_player.setInfo(topInfo);
+    m_top_player.setPlayerColor(core::Color::White);
+    m_bottom_player.setPlayerColor(core::Color::Black);
+    m_white_player = &m_top_player;
+    m_black_player = &m_bottom_player;
+    m_top_clock.setPlayerColor(core::Color::White);
+    m_bottom_clock.setPlayerColor(core::Color::Black);
+    m_white_clock = &m_top_clock;
+    m_black_clock = &m_bottom_clock;
+  } else {
+    m_top_player.setInfo(topInfo);
+    m_bottom_player.setInfo(bottomInfo);
+    m_top_player.setPlayerColor(core::Color::Black);
+    m_bottom_player.setPlayerColor(core::Color::White);
+    m_black_player = &m_top_player;
+    m_white_player = &m_bottom_player;
+    m_top_clock.setPlayerColor(core::Color::Black);
+    m_bottom_clock.setPlayerColor(core::Color::White);
+    m_black_clock = &m_top_clock;
+    m_white_clock = &m_bottom_clock;
+  }
 
   // board orientation
-  m_board_view.setFlipped(bottomIsBot && !topIsBot);
+  m_board_view.setFlipped(flipped);
 
   // initial layout
   layout(m_window.getSize().x, m_window.getSize().y);


### PR DESCRIPTION
## Summary
- swap player info and clocks when board is flipped so choosing black shows correct players
- rework premove queue to operate on pseudo-legal moves without moving pieces
- rehighlight remaining premoves and auto-play queued moves safely

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: Bitboard not declared, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f11273dc832997aa88ecd8b7afc4