### PR TITLE
Allow chained premoves with virtual board

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -24,6 +24,10 @@ class Event;
 namespace lilia::model {
 class ChessGame;
 struct Move;
+class Position;
+namespace bb {
+struct Piece;
+}
 } // namespace lilia::model
 
 namespace lilia::controller {
@@ -42,6 +46,8 @@ struct Premove {
   core::Square to;
   core::PieceType capturedType;
   core::Color capturedColor;
+};
+
 struct TimeView {
   float white;
   float black;
@@ -103,6 +109,9 @@ private:
   void clearPremove();
   void enqueuePremove(core::Square from, core::Square to);
   [[nodiscard]] bool isPseudoLegalPremove(core::Square from, core::Square to) const;
+  [[nodiscard]] model::Position getPositionAfterPremoves() const;
+  [[nodiscard]] model::bb::Piece getPieceConsideringPremoves(core::Square sq) const;
+  [[nodiscard]] bool hasVirtualPiece(core::Square sq) const;
 
   void movePieceAndClear(const model::Move &move, bool isPlayerMove,
                          bool onClick);

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -95,6 +95,8 @@ class GameView {
   void clearHighlightPremoveSquare(core::Square pos);
   void clearPremoveHighlights();
   void clearAllHighlights();
+  void clearNonPremoveHighlights();
+  void clearAttackHighlights();
 
   void warningKingSquareAnim(core::Square ksq);
   void animationSnapAndReturn(core::Square sq, core::MousePos mousePos);

--- a/include/lilia/view/highlight_manager.hpp
+++ b/include/lilia/view/highlight_manager.hpp
@@ -17,6 +17,8 @@ class HighlightManager {
   void highlightHoverSquare(core::Square pos);
   void highlightPremoveSquare(core::Square pos);
   void clearAllHighlights();
+  void clearNonPremoveHighlights();
+  void clearAttackHighlights();
   void clearHighlightSquare(core::Square pos);
   void clearHighlightHoverSquare(core::Square pos);
   void clearHighlightPremoveSquare(core::Square pos);

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -398,6 +398,12 @@ void GameView::clearPremoveHighlights() {
 void GameView::clearAllHighlights() {
   m_highlight_manager.clearAllHighlights();
 }
+void GameView::clearNonPremoveHighlights() {
+  m_highlight_manager.clearNonPremoveHighlights();
+}
+void GameView::clearAttackHighlights() {
+  m_highlight_manager.clearAttackHighlights();
+}
 
 // ---------- Animations ----------
 void GameView::warningKingSquareAnim(core::Square ksq) {

--- a/src/lilia/view/highlight_manager.cpp
+++ b/src/lilia/view/highlight_manager.cpp
@@ -63,6 +63,12 @@ void HighlightManager::clearAllHighlights() {
   m_hl_hover_squares.clear();
   m_hl_premove_squares.clear();
 }
+void HighlightManager::clearNonPremoveHighlights() {
+  m_hl_select_squares.clear();
+  m_hl_attack_squares.clear();
+  m_hl_hover_squares.clear();
+}
+void HighlightManager::clearAttackHighlights() { m_hl_attack_squares.clear(); }
 void HighlightManager::clearHighlightSquare(core::Square pos) {
   m_hl_select_squares.erase(pos);
 }


### PR DESCRIPTION
## Summary
- Recompute pseudo-legal premoves on a virtual board so chained premoves work from future squares
- Keep premove highlights while clearing other highlight types and remove stale attack highlights
- Add helper APIs for managing premove vs. non-premove highlights

## Testing
- `cmake -S . -B build`
- `cmake --build build --target lilia_app -j $(nproc)` *(fails: undefined reference to X11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fdcf37ac832984a0dc42df31e22f