### PR TITLE
Fix premove piece visibility

### DIFF
--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -98,6 +98,10 @@ class GameView {
   void clearNonPremoveHighlights();
   void clearAttackHighlights();
 
+  // Preview helpers for premoves
+  void showPremovePiece(core::Square from, core::Square to);
+  void clearPremovePieces();
+
   void warningKingSquareAnim(core::Square ksq);
   void animationSnapAndReturn(core::Square sq, core::MousePos mousePos);
   void animationMovePiece(core::Square from, core::Square to,

--- a/include/lilia/view/piece_manager.hpp
+++ b/include/lilia/view/piece_manager.hpp
@@ -38,11 +38,17 @@ class PieceManager {
   void renderPieces(sf::RenderWindow& window, const animation::ChessAnimator& chessAnimRef);
   void renderPiece(core::Square pos, sf::RenderWindow& window);
 
+  // Visual-only helpers for premove previews
+  void setPremovePiece(core::Square from, core::Square to);
+  void clearPremovePieces();
+
  private:
   Entity::Position createPiecePositon(core::Square pos);
 
   const BoardView& m_board_view_ref;
   std::unordered_map<core::Square, Piece> m_pieces;
+  // Pieces rendered for premove visualization without affecting board state
+  std::unordered_map<core::Square, Piece> m_premove_pieces;
 };
 
 }  // namespace lilia::view

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -533,12 +533,17 @@ void GameController::enqueuePremove(core::Square from, core::Square to) {
   m_game_view.highlightPremoveSquare(from);
   m_game_view.highlightPremoveSquare(to);
   m_premove_queue.push_back(pm);
+  if (!m_premove_queue.empty()) {
+    const auto &front = m_premove_queue.front();
+    m_game_view.showPremovePiece(front.from, front.to);
+  }
 }
 
 void GameController::clearPremove() {
   if (!m_premove_queue.empty()) {
     m_premove_queue.clear();
     m_game_view.clearPremoveHighlights();
+    m_game_view.clearPremovePieces();
     highlightLastMove();
   }
 }
@@ -647,6 +652,12 @@ void GameController::movePieceAndClear(const model::Move &move, bool isPlayerMov
     for (const auto &remaining : m_premove_queue) {
       m_game_view.highlightPremoveSquare(remaining.from);
       m_game_view.highlightPremoveSquare(remaining.to);
+    }
+    if (!m_premove_queue.empty()) {
+      const auto &front = m_premove_queue.front();
+      m_game_view.showPremovePiece(front.from, front.to);
+    } else {
+      m_game_view.clearPremovePieces();
     }
   }
 }

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -404,6 +404,14 @@ void GameView::clearNonPremoveHighlights() {
 void GameView::clearAttackHighlights() {
   m_highlight_manager.clearAttackHighlights();
 }
+void GameView::showPremovePiece(core::Square from, core::Square to) {
+  m_piece_manager.setPremovePiece(from, to);
+}
+
+void GameView::clearPremovePieces() {
+  m_piece_manager.clearPremovePieces();
+}
+
 
 // ---------- Animations ----------
 void GameView::warningKingSquareAnim(core::Square ksq) {

--- a/src/lilia/view/piece_manager.cpp
+++ b/src/lilia/view/piece_manager.cpp
@@ -159,6 +159,10 @@ void PieceManager::renderPieces(sf::RenderWindow& window,
       piece.draw(window);
     }
   }
+  // Draw premove preview pieces on top of regular pieces
+  for (auto& pair : m_premove_pieces) {
+    pair.second.draw(window);
+  }
 }
 
 void PieceManager::renderPiece(core::Square pos, sf::RenderWindow& window) {
@@ -167,5 +171,16 @@ void PieceManager::renderPiece(core::Square pos, sf::RenderWindow& window) {
     it->second.draw(window);
   }
 }
+
+void PieceManager::setPremovePiece(core::Square from, core::Square to) {
+  auto it = m_pieces.find(from);
+  if (it == m_pieces.end()) return;
+  Piece ghost = it->second;  // copy to preserve original
+  ghost.setPosition(createPiecePositon(to));
+  m_premove_pieces.clear();
+  m_premove_pieces[to] = std::move(ghost);
+}
+
+void PieceManager::clearPremovePieces() { m_premove_pieces.clear(); }
 
 }  // namespace lilia::view


### PR DESCRIPTION
## Summary
- preview next premove by drawing a copy of the piece on its destination square
- clear premove preview pieces when queue changes

## Testing
- `cmake -S . -B build` *(fails: Could NOT find VORBIS lib; after installing dependencies build fails linking X11; see logs)*
- `cmake --build build` *(fails: undefined references to X11 functions)*

------
https://chatgpt.com/codex/tasks/task_e_68b6072977c883299a300bc64bfd2233