### PR TITLE
Fix premove visuals and add sound effect

### DIFF
--- a/include/lilia/view/audio/sound_manager.hpp
+++ b/include/lilia/view/audio/sound_manager.hpp
@@ -16,7 +16,8 @@ enum class Effect {
   Castle,
   Promotion,
   GameBegins,
-  GameEnds
+  GameEnds,
+  Premove
 };
 
 class SoundManager {

--- a/include/lilia/view/render_constants.hpp
+++ b/include/lilia/view/render_constants.hpp
@@ -77,5 +77,6 @@ const std::string SFX_CHECK_NAME = "check";
 const std::string SFX_PROMOTION_NAME = "promotion";
 const std::string SFX_GAME_BEGINS_NAME = "game_begins";
 const std::string SFX_GAME_ENDS_NAME = "game_ends";
+const std::string SFX_PREMOVE_NAME = "pre_move";
 
 }  // namespace lilia::view::constant

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -533,6 +533,7 @@ void GameController::enqueuePremove(core::Square from, core::Square to) {
   m_game_view.highlightPremoveSquare(from);
   m_game_view.highlightPremoveSquare(to);
   m_premove_queue.push_back(pm);
+  m_sound_manager.playEffect(view::sound::Effect::Premove);
   if (!m_premove_queue.empty()) {
     const auto &front = m_premove_queue.front();
     core::Square dest = getFrontPremoveDestination();
@@ -717,6 +718,9 @@ void GameController::snapAndReturn(core::Square sq, core::MousePos cur) {
 }
 
 void GameController::showAttacks(std::vector<core::Square> att) {
+  // Always clear previous attack highlights so stale squares don't linger when
+  // previewing or chaining premoves.
+  m_game_view.clearAttackHighlights();
   for (auto sq : att) {
     if (hasVirtualPiece(sq))
       m_game_view.highlightCaptureSquare(sq);

--- a/src/lilia/view/audio/sound_manager.cpp
+++ b/src/lilia/view/audio/sound_manager.cpp
@@ -14,6 +14,7 @@ void SoundManager::loadSounds() {
   loadEffect(constant::SFX_PLAYER_MOVE_NAME, constant::ASSET_SFX_FILE_PATH);
   loadEffect(constant::SFX_PROMOTION_NAME, constant::ASSET_SFX_FILE_PATH);
   loadEffect(constant::SFX_WARNING_NAME, constant::ASSET_SFX_FILE_PATH);
+  loadEffect(constant::SFX_PREMOVE_NAME, constant::ASSET_SFX_FILE_PATH);
 }
 
 void SoundManager::playEffect(Effect effect) {
@@ -46,6 +47,9 @@ void SoundManager::playEffect(Effect effect) {
       break;
     case Effect::GameEnds:
       m_sounds[constant::SFX_GAME_ENDS_NAME].play();
+      break;
+    case Effect::Premove:
+      m_sounds[constant::SFX_PREMOVE_NAME].play();
       break;
   }
 }

--- a/src/lilia/view/piece_manager.cpp
+++ b/src/lilia/view/piece_manager.cpp
@@ -217,7 +217,9 @@ void PieceManager::setPremovePiece(core::Square from, core::Square to) {
   ghost.setPosition(createPiecePositon(to));
   m_premove_pieces.clear();
   m_premove_pieces[to] = std::move(ghost);
-  m_hidden_squares.clear();
+  // Keep the original piece hidden as long as a premove is pending. Avoid
+  // clearing previously hidden squares so the real piece never pops back into
+  // view when chaining multiple premoves.
   m_hidden_squares.insert(from);
   if (m_pieces.find(to) != m_pieces.end()) m_hidden_squares.insert(to);
 }


### PR DESCRIPTION
## Summary
- Clear previous attack highlights before showing new ones to support premoved pieces
- Keep original pieces hidden during premove preview to prevent duplicate visuals
- Play a dedicated sound effect whenever a premove is queued

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: undefined X11 references)*

------
https://chatgpt.com/codex/tasks/task_e_68b60f710d9083299e38bacdf06ebdac