### PR TITLE
fix: hide premove ghost during move

### DIFF
--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -555,6 +555,11 @@ void GameController::movePieceAndClear(const model::Move &move, bool isPlayerMov
   const core::Square from = move.from;
   const core::Square to = move.to;
 
+  // Ensure any premove preview piece is hidden before the real move animates.
+  // Otherwise both the preview ghost and the actual piece would be visible
+  // simultaneously while the move animation is playing.
+  m_game_view.clearPremovePieces();
+
   // 1) Drag-Konflikt defensiv auflösen
   if (m_dragging && m_drag_from == from) {
     m_dragging = false;


### PR DESCRIPTION
## Summary
- Clear premove preview pieces before move animations start to prevent ghost and real pieces showing simultaneously

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b614845a288329bf9661b0472bbf57