### PR TITLE
Fix premove chain and visualization

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -108,10 +108,10 @@ private:
   void dehoverSquare();
   void clearPremove();
   void enqueuePremove(core::Square from, core::Square to);
+  void updatePremovePreviews();
   [[nodiscard]] bool isPseudoLegalPremove(core::Square from, core::Square to) const;
   [[nodiscard]] model::Position getPositionAfterPremoves() const;
   [[nodiscard]] model::bb::Piece getPieceConsideringPremoves(core::Square sq) const;
-  [[nodiscard]] core::Square getFrontPremoveDestination() const;
   [[nodiscard]] bool hasVirtualPiece(core::Square sq) const;
 
   void movePieceAndClear(const model::Move &move, bool isPlayerMove,

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -535,11 +535,7 @@ void GameController::enqueuePremove(core::Square from, core::Square to) {
   m_game_view.highlightPremoveSquare(to);
   m_premove_queue.push_back(pm);
   m_sound_manager.playEffect(view::sound::Effect::Premove);
-  if (!m_premove_queue.empty()) {
-    const auto &front = m_premove_queue.front();
-    core::Square dest = getFrontPremoveDestination();
-    m_game_view.showPremovePiece(front.from, dest);
-  }
+  updatePremovePreviews();
 }
 
 void GameController::clearPremove() {
@@ -548,6 +544,13 @@ void GameController::clearPremove() {
     m_game_view.clearPremoveHighlights();
     m_game_view.clearPremovePieces();
     highlightLastMove();
+  }
+}
+
+void GameController::updatePremovePreviews() {
+  m_game_view.clearPremovePieces();
+  for (const auto &pm : m_premove_queue) {
+    m_game_view.showPremovePiece(pm.from, pm.to);
   }
 }
 
@@ -656,13 +659,7 @@ void GameController::movePieceAndClear(const model::Move &move, bool isPlayerMov
       m_game_view.highlightPremoveSquare(remaining.from);
       m_game_view.highlightPremoveSquare(remaining.to);
     }
-    if (!m_premove_queue.empty()) {
-      const auto &front = m_premove_queue.front();
-      core::Square dest = getFrontPremoveDestination();
-      m_game_view.showPremovePiece(front.from, dest);
-    } else {
-      m_game_view.clearPremovePieces();
-    }
+    updatePremovePreviews();
   }
 }
 
@@ -974,18 +971,6 @@ model::bb::Piece GameController::getPieceConsideringPremoves(core::Square sq) co
   model::Position pos = getPositionAfterPremoves();
   if (auto virt = pos.getBoard().getPiece(sq)) return *virt;
   return pc;
-}
-
-core::Square GameController::getFrontPremoveDestination() const {
-  if (m_premove_queue.empty()) return core::NO_SQUARE;
-  core::Square dest = m_premove_queue.front().to;
-  for (size_t i = 1; i < m_premove_queue.size(); ++i) {
-    if (m_premove_queue[i].from == dest)
-      dest = m_premove_queue[i].to;
-    else
-      break;
-  }
-  return dest;
 }
 
 bool GameController::hasVirtualPiece(core::Square sq) const {


### PR DESCRIPTION
## Summary
- Keep track of multiple premoved pieces without replacing them on capture
- Rebuild premove previews for entire queue after each update
- Clean up unused premove destination logic

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY OPENGL_INCLUDE_DIR))*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68b61d38d600832987711a7cd1852702