### PR TITLE
Fix premove ghost handling and captures

### DIFF
--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -100,7 +100,7 @@ class GameView {
 
   // Preview helpers for premoves
   void showPremovePiece(core::Square from, core::Square to);
-  void clearPremovePieces();
+  void clearPremovePieces(bool restore = true);
 
   void warningKingSquareAnim(core::Square ksq);
   void animationSnapAndReturn(core::Square sq, core::MousePos mousePos);

--- a/include/lilia/view/piece_manager.hpp
+++ b/include/lilia/view/piece_manager.hpp
@@ -41,7 +41,7 @@ class PieceManager {
 
   // Visual-only helpers for premove previews
   void setPremovePiece(core::Square from, core::Square to);
-  void clearPremovePieces();
+  void clearPremovePieces(bool restore = true);
 
  private:
   Entity::Position createPiecePositon(core::Square pos);
@@ -52,6 +52,8 @@ class PieceManager {
   std::unordered_map<core::Square, Piece> m_premove_pieces;
   // Squares hidden from the main piece map during premove preview
   std::unordered_set<core::Square> m_hidden_squares;
+  // Backup of pieces temporarily removed due to premove captures
+  std::unordered_map<core::Square, Piece> m_captured_backup;
 };
 
 }  // namespace lilia::view

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -477,7 +477,7 @@ void GameController::update(float dt) {
     const auto st = m_chess_game.getGameState();
     if (m_game_manager && m_game_manager->isHuman(st.sideToMove) &&
         hasCurrentLegalMove(m_pending_from, m_pending_to)) {
-      m_game_view.clearPremovePieces();
+      m_game_view.clearPremovePieces(false);
       m_game_view.movePiece(m_pending_from, m_pending_to);
       (void)m_game_manager->requestUserMove(m_pending_from, m_pending_to,
                                             /*onClick*/ true);

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -408,8 +408,8 @@ void GameView::showPremovePiece(core::Square from, core::Square to) {
   m_piece_manager.setPremovePiece(from, to);
 }
 
-void GameView::clearPremovePieces() {
-  m_piece_manager.clearPremovePieces();
+void GameView::clearPremovePieces(bool restore) {
+  m_piece_manager.clearPremovePieces(restore);
 }
 
 


### PR DESCRIPTION
## Summary
- keep premove ghosts visible across chained moves
- preserve and restore pieces captured during premove preview
- allow clearing premove visuals without restoring captured pieces

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build --config Release` *(fails: undefined X11 references)*

------
https://chatgpt.com/codex/tasks/task_e_68b624f9cd148329a2d904b931413cbd