### PR TITLE
Fix premove capture visibility

### DIFF
--- a/include/lilia/view/piece_manager.hpp
+++ b/include/lilia/view/piece_manager.hpp
@@ -53,8 +53,8 @@ class PieceManager {
   std::unordered_map<core::Square, Piece> m_premove_pieces;
   // Squares hidden from the main piece map during premove preview
   std::unordered_set<core::Square> m_hidden_squares;
-  // Backup of pieces temporarily removed due to premove captures
-  std::unordered_map<core::Square, Piece> m_captured_backup;
+  // No separate backup is needed; captured pieces remain in the main map
+  // and are only hidden during premove previews.
 };
 
 }  // namespace lilia::view

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -545,7 +545,7 @@ void GameController::clearPremove() {
   if (!m_premove_queue.empty()) {
     m_premove_queue.clear();
     m_game_view.clearPremoveHighlights();
-    m_game_view.clearPremovePieces(true);  // restore any stashed captures
+    m_game_view.clearPremovePieces(true);  // restore hidden pieces
     highlightLastMove();
   }
 }

--- a/src/lilia/view/piece_manager.cpp
+++ b/src/lilia/view/piece_manager.cpp
@@ -236,12 +236,8 @@ void PieceManager::setPremovePiece(core::Square from, core::Square to) {
     m_hidden_squares.insert(from);
   }
 
-  // If destination has a *real* piece, stash it so cancel restores it
-  auto captured = m_pieces.find(to);
-  if (captured != m_pieces.end()) {
-    m_captured_backup[to] = std::move(captured->second);
-    m_pieces.erase(captured);
-  }
+  // Destination pieces remain in the main map so the opponent can still move
+  // them before the premove executes; hiding the square is enough.
 
   ghost.setPosition(createPiecePositon(to));
 
@@ -259,20 +255,14 @@ void PieceManager::consumePremoveGhost(core::Square from, core::Square to) {
   if (it != m_premove_pieces.end()) m_premove_pieces.erase(it);
 
   // The move will actually be applied by the caller (real piece drawn),
-  // so unhide involved squares and drop any stashed victim for 'to'
+  // so unhide involved squares
   m_hidden_squares.erase(from);
   m_hidden_squares.erase(to);
-  m_captured_backup.erase(to);
 }
 
-void PieceManager::clearPremovePieces(bool restore) {
-  if (restore) {
-    for (auto& pair : m_captured_backup) {
-      m_pieces[pair.first] = std::move(pair.second);
-      m_pieces[pair.first].setPosition(createPiecePositon(pair.first));
-    }
-  }
-  m_captured_backup.clear();
+void PieceManager::clearPremovePieces(bool /*restore*/) {
+  // No pieces were removed from the main map during preview, so clearing
+  // premove state only needs to drop ghosts and reveal hidden squares.
   m_premove_pieces.clear();
   m_hidden_squares.clear();
 }


### PR DESCRIPTION
## Summary
- stop deleting opponent pieces during premove preview and instead hide them
- simplify premove cleanup logic and update controller comments

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b630247b0083299fa9994ffa23577b