### PR TITLE
Add board overlay when reviewing move history

### DIFF
--- a/include/lilia/view/board_view.hpp
+++ b/include/lilia/view/board_view.hpp
@@ -4,6 +4,7 @@
 
 #include "../controller/mousepos.hpp"
 #include "board.hpp"
+#include "entity.hpp"
 
 namespace lilia::view {
 
@@ -13,6 +14,7 @@ public:
 
   void init();
   void renderBoard(sf::RenderWindow &window);
+  void renderHistoryOverlay(sf::RenderWindow &window);
   [[nodiscard]] Entity::Position getSquareScreenPos(core::Square sq) const;
   void toggleFlipped();
   void setFlipped(bool flipped);
@@ -22,6 +24,8 @@ public:
                                  Entity::Position pieceSize = {0.f, 0.f}) const noexcept;
   [[nodiscard]] core::Square mousePosToSquare(core::MousePos mousePos) const;
 
+  void setHistoryOverlay(bool show);
+
   void setPosition(const Entity::Position &pos);
   [[nodiscard]] Entity::Position getPosition() const;
 
@@ -30,6 +34,8 @@ private:
   Entity::Position m_flip_pos{};
   float m_flip_size{0.f};
   bool m_flipped{false};
+  Entity m_history_overlay;
+  bool m_show_history_overlay{false};
 };
 
 } // namespace lilia::view

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -44,6 +44,7 @@ class GameView {
   void updateFen(const std::string &fen);
   void scrollMoveList(float delta);
   void setBotMode(bool anyBot);
+  void setHistoryOverlay(bool show);
 
   [[nodiscard]] std::size_t getMoveIndexAt(core::MousePos mousePos) const;
   [[nodiscard]] MoveListView::Option getOptionAt(core::MousePos mousePos) const;

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -63,6 +63,7 @@ GameController::GameController(view::GameView &gView, model::ChessGame &game)
     // If the user is viewing history, jump back to head before applying
     if (this->m_fen_index != this->m_fen_history.size() - 1) {
       this->m_fen_index = this->m_fen_history.size() - 1;
+      this->m_game_view.setHistoryOverlay(false);
       this->m_game_view.setBoardFen(this->m_fen_history[this->m_fen_index]);
       this->m_eval_cp.store(this->m_eval_history[this->m_fen_index]);
       this->m_game_view.updateEval(this->m_eval_history[this->m_fen_index]);
@@ -89,6 +90,7 @@ GameController::GameController(view::GameView &gView, model::ChessGame &game)
     this->m_fen_history.push_back(this->m_chess_game.getFen());
     this->m_eval_history.push_back(this->m_eval_cp.load());
     this->m_fen_index = this->m_fen_history.size() - 1;
+    this->m_game_view.setHistoryOverlay(false);
     this->m_game_view.updateFen(this->m_fen_history.back());
     this->m_game_view.selectMove(this->m_fen_index ? this->m_fen_index - 1
                                                    : static_cast<std::size_t>(-1));
@@ -154,6 +156,7 @@ void GameController::startGame(const std::string &fen, bool whiteIsBot, bool bla
   m_fen_history.push_back(fen);
   m_eval_history.push_back(m_eval_cp.load());
   m_fen_index = 0;
+  m_game_view.setHistoryOverlay(false);
   m_move_history.clear();
   m_game_view.selectMove(static_cast<std::size_t>(-1));
   m_eval_cp.store(m_eval_history[0]);
@@ -297,6 +300,7 @@ void GameController::handleEvent(const sf::Event &event) {
           m_game_view.setClockActive(std::nullopt);
       }
       syncCapturedPieces();
+      m_game_view.setHistoryOverlay(m_fen_index != m_fen_history.size() - 1);
       return;
     }
   }
@@ -1164,6 +1168,7 @@ void GameController::stepBackward() {
     }
     syncCapturedPieces();
   }
+  m_game_view.setHistoryOverlay(m_fen_index != m_fen_history.size() - 1);
 }
 
 void GameController::stepForward() {
@@ -1227,6 +1232,7 @@ void GameController::stepForward() {
     updatePremovePreviews();
     m_premove_suspended = false;
   }
+  m_game_view.setHistoryOverlay(m_fen_index != m_fen_history.size() - 1);
 }
 
 void GameController::resign() {

--- a/src/lilia/view/board_view.cpp
+++ b/src/lilia/view/board_view.cpp
@@ -179,12 +179,18 @@ BoardView::BoardView()
     : m_board({constant::WINDOW_PX_SIZE / 2, constant::WINDOW_PX_SIZE / 2}),
       m_flip_pos(),
       m_flip_size(0.f),
-      m_flipped(false) {}
+      m_flipped(false),
+      m_show_history_overlay(false) {}
 
 void BoardView::init() {
   m_board.init(TextureTable::getInstance().get(constant::STR_TEXTURE_WHITE),
                TextureTable::getInstance().get(constant::STR_TEXTURE_BLACK),
                TextureTable::getInstance().get(constant::STR_TEXTURE_TRANSPARENT));
+  m_history_overlay.setTexture(
+      TextureTable::getInstance().get(constant::STR_TEXTURE_HISTORY_OVERLAY));
+  m_history_overlay.setScale(constant::WINDOW_PX_SIZE, constant::WINDOW_PX_SIZE);
+  m_history_overlay.setOriginToCenter();
+  m_show_history_overlay = false;
   setPosition(getPosition());
 }
 
@@ -205,6 +211,12 @@ void BoardView::renderBoard(sf::RenderWindow& window) {
     const float cx = slot.left + slot.width * 0.5f;
     const float cy = slot.top + slot.height * 0.5f;
     drawTooltip(window, {cx, cy}, "Flip board");
+  }
+}
+
+void BoardView::renderHistoryOverlay(sf::RenderWindow& window) {
+  if (m_show_history_overlay) {
+    m_history_overlay.draw(window);
   }
 }
 
@@ -232,6 +244,7 @@ void BoardView::setFlipped(bool flipped) {
 
 void BoardView::setPosition(const Entity::Position& pos) {
   m_board.setPosition(pos);
+  m_history_overlay.setPosition(pos);
   float iconOffset = constant::SQUARE_PX_SIZE * 0.2f;
   m_flip_size = constant::SQUARE_PX_SIZE * 0.3f;
   m_flip_pos = {pos.x + constant::WINDOW_PX_SIZE / 2.f + iconOffset,
@@ -309,6 +322,10 @@ core::Square BoardView::mousePosToSquare(core::MousePos mousePos) const {
   }
 
   return static_cast<core::Square>(rankFromWhite * 8 + fileFromWhite);
+}
+
+void BoardView::setHistoryOverlay(bool show) {
+  m_show_history_overlay = show;
 }
 
 }  // namespace lilia::view

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -84,6 +84,7 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
 
 void GameView::init(const std::string &fen) {
   m_board_view.init();
+  m_board_view.setHistoryOverlay(false);
   m_piece_manager.initFromFen(fen);
   m_move_list.clear();
   m_eval_bar.reset();
@@ -114,6 +115,7 @@ void GameView::render() {
   m_piece_manager.renderPieces(m_window, m_chess_animator);
   m_highlight_manager.renderAttack(m_window);
   m_chess_animator.render(m_window);
+  m_board_view.renderHistoryOverlay(m_window);
   if (m_show_clocks) {
     m_top_clock.render(m_window);
     m_bottom_clock.render(m_window);
@@ -180,6 +182,10 @@ void GameView::scrollMoveList(float delta) {
 
 void GameView::setBotMode(bool anyBot) {
   m_move_list.setBotMode(anyBot);
+}
+
+void GameView::setHistoryOverlay(bool show) {
+  m_board_view.setHistoryOverlay(show);
 }
 
 std::size_t GameView::getMoveIndexAt(core::MousePos mousePos) const {


### PR DESCRIPTION
## Summary
- show translucent overlay over board when browsing past positions
- expose overlay toggle to GameView and controller
- automatically enable/disable overlay while stepping through move history

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b63d3bdb648329b2118fd107aad9b1