### PR TITLE
Prevent unintended closing of bot lists on start screen

### DIFF
--- a/src/lilia/view/start_screen.cpp
+++ b/src/lilia/view/start_screen.cpp
@@ -522,7 +522,7 @@ bool StartScreen::handleMouse(sf::Vector2f pos, StartConfig& cfg) {
         cfg.whiteBot = m_whiteBotOptions[i].type;
         m_whiteBotText.setString(botDisplayName(cfg.whiteBot));
         m_showWhiteBotList = false;
-        break;
+        return false;
       }
     }
   }
@@ -545,7 +545,7 @@ bool StartScreen::handleMouse(sf::Vector2f pos, StartConfig& cfg) {
         cfg.blackBot = m_blackBotOptions[i].type;
         m_blackBotText.setString(botDisplayName(cfg.blackBot));
         m_showBlackBotList = false;
-        break;
+        return false;
       }
     }
   }


### PR DESCRIPTION
## Summary
- fix start screen bug that closed both bot lists when selecting a bot

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b64151c1f083299ec3766215c97911