### PR TITLE
Hide move history overlay when game ends

### DIFF
--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -200,6 +200,10 @@ MoveListView::Option GameView::getOptionAt(core::MousePos mousePos) const {
 
 void GameView::setGameOver(bool over) {
   m_move_list.setGameOver(over);
+  if (over) {
+    // Ensure move history overlay is hidden when the game is finished
+    m_board_view.setHistoryOverlay(false);
+  }
 }
 
 /* ---------- Modals ---------- */


### PR DESCRIPTION
## Summary
- Ensure move history overlay is turned off once the game finishes so move list overlay isn't visible after completion.

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68b644701b688329b35fba52a6a4df1f