### PR TITLE
Fix resignation result and clear premove after game end

### DIFF
--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -1056,6 +1056,11 @@ void GameController::showGameOver(core::GameResult res, core::Color sideToMove) 
   m_dragging = false;
   m_game_view.setDefaultCursor();
 
+  // Ensure no premove state or visuals linger after the game ends
+  m_premove_queue.clear();
+  m_game_view.clearPremoveHighlights();
+  m_game_view.clearPremovePieces(true);
+
   if (m_time_controller) {
     m_time_controller->stop();
     m_game_view.setClockActive(std::nullopt);
@@ -1250,7 +1255,11 @@ void GameController::resign() {
   m_chess_game.setResult(core::GameResult::CHECKMATE);
   m_game_view.clearAllHighlights();
   highlightLastMove();
-  showGameOver(core::GameResult::CHECKMATE, m_chess_game.getGameState().sideToMove);
+  core::Color loser = m_chess_game.getGameState().sideToMove;
+  if (m_game_manager && !m_game_manager->isHuman(loser)) {
+    loser = ~loser;
+  }
+  showGameOver(core::GameResult::CHECKMATE, loser);
 }
 
 GameController::NextAction GameController::getNextAction() const {


### PR DESCRIPTION
## Summary
- Ensure resigning side is marked as the loser
- Clear premove queue and highlights when the game ends

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b648e1b4ac83299246b3cdfb3dd193