### PR TITLE
Improve premove ghost handling for special moves

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -44,6 +44,7 @@ struct MoveView {
 struct Premove {
   core::Square from;
   core::Square to;
+  core::PieceType promotion = core::PieceType::None;
   core::PieceType capturedType;
   core::Color capturedColor;
 };
@@ -157,6 +158,7 @@ private:
   core::Square m_pending_from = core::NO_SQUARE;
   core::Square m_pending_to = core::NO_SQUARE;
   core::PieceType m_pending_capture_type = core::PieceType::None;
+  core::PieceType m_pending_promotion = core::PieceType::None;
   bool m_skip_next_move_animation = false;
 
   core::Square m_selected_sq = core::NO_SQUARE; ///< Currently selected square.

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -104,7 +104,8 @@ class GameView {
   void clearAttackHighlights();
 
   // Preview helpers for premoves
-  void showPremovePiece(core::Square from, core::Square to);
+  void showPremovePiece(core::Square from, core::Square to,
+                        core::PieceType promotion = core::PieceType::None);
   void clearPremovePieces(bool restore = true);
 
   void warningKingSquareAnim(core::Square ksq);

--- a/include/lilia/view/piece_manager.hpp
+++ b/include/lilia/view/piece_manager.hpp
@@ -40,7 +40,9 @@ class PieceManager {
   void renderPiece(core::Square pos, sf::RenderWindow& window);
 
   // Visual-only helpers for premove previews
-  void setPremovePiece(core::Square from, core::Square to);
+  // Optional promotion piece allows the ghost to differ from the original type
+  void setPremovePiece(core::Square from, core::Square to,
+                       core::PieceType promotion = core::PieceType::None);
   void clearPremovePieces(bool restore = true);
   void consumePremoveGhost(core::Square from, core::Square to);
   void applyPremoveInstant(core::Square from, core::Square to,

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -436,8 +436,9 @@ void GameView::clearAttackHighlights() {
   m_highlight_manager.clearAttackHighlights();
 }
 
-void GameView::showPremovePiece(core::Square from, core::Square to) {
-  m_piece_manager.setPremovePiece(from, to);
+void GameView::showPremovePiece(core::Square from, core::Square to,
+                                core::PieceType promotion) {
+  m_piece_manager.setPremovePiece(from, to, promotion);
 }
 
 void GameView::clearPremovePieces(bool restore) {


### PR DESCRIPTION
## Summary
- Allow premove previews to specify a promotion piece and render appropriate ghost textures
- Queue and execute promotion and castling premoves, including instant rook moves and promotion completion
- Cancel all queued premoves by clicking on any board square and fix ghost captures so premove targets stay visible

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*
- `cmake --build build --config Release` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68b659cbcbb88329b6970c59ceee374b