### PR TITLE
Fix premove queue after move

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -47,6 +47,7 @@ struct Premove {
   core::PieceType promotion = core::PieceType::None;
   core::PieceType capturedType;
   core::Color capturedColor;
+  core::Color moverColor;
 };
 
 struct TimeView {


### PR DESCRIPTION
## Summary
- track which color created a premove
- only process queued premove when that color is to move
- keep virtual position in sync with premove color

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b67d308e608329a6bab7ac3d2cb7c5