### PR TITLE
Fix deselection/highlight clearing when not player's turn

### DIFF
--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -1021,8 +1021,12 @@ void GameController::onClick(core::MousePos mousePos) {
       return;  // don't reselect
     }
     if (!ownTurnAndPiece && canPremove) {
-      enqueuePremove(m_selected_sq, sq);
-      m_selected_sq = core::NO_SQUARE;
+      if (sq == m_selected_sq) {
+        deselectSquare();
+      } else {
+        enqueuePremove(m_selected_sq, sq);
+        deselectSquare();
+      }
       return;  // don't reselect
     }
 


### PR DESCRIPTION
## Summary
- Allow deselecting a piece by clicking it again when it's not the player's turn
- Clear selection/highlights when clicking an empty square while preparing a premove

## Testing
- `cmake -S . -B build`
- `cmake --build build --config Release` *(fails: fatal error: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6baf4adb88329a84a2fdacc8c1d7f