### PR TITLE
Fix premove promotion and overlay ordering

### DIFF
--- a/include/lilia/view/animation/promotion_select_animation.hpp
+++ b/include/lilia/view/animation/promotion_select_animation.hpp
@@ -8,7 +8,8 @@ namespace lilia::view::animation {
 
 class PromotionSelectAnim : public IAnimation {
  public:
-  PromotionSelectAnim(Entity::Position prPos, PromotionManager& prOptRef, core::Color c);
+  PromotionSelectAnim(Entity::Position prPos, PromotionManager& prOptRef, core::Color c,
+                      bool upwards);
   void update(float dt) override;
   void draw(sf::RenderWindow& window) override;
   [[nodiscard]] inline bool isFinished() const override;

--- a/include/lilia/view/promotion_manager.hpp
+++ b/include/lilia/view/promotion_manager.hpp
@@ -12,7 +12,7 @@ class PromotionManager {
 
   bool hasOptions();
   void render(sf::RenderWindow& window);
-  void fillOptions(Entity::Position prPos, core::Color c);
+  void fillOptions(Entity::Position prPos, core::Color c, bool upwards);
   void removeOptions();
   Entity::Position getCenterPosition();
   core::PieceType clickedOnType(Entity::Position mousePos);

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -502,20 +502,21 @@ void GameController::update(float dt) {
         m_game_view.applyPremoveInstant(rookFrom, rookTo, core::PieceType::None);
       }
 
-      // 2) Hand it to the game manager (synchronous acceptance)
-      const bool accepted = m_game_manager
-                                ? m_game_manager->requestUserMove(m_pending_from, m_pending_to,
-                                                                  /*onClick*/ true)
-                                : false;
+      // 2) Hand it to the game manager and handle promotion immediately
+      bool accepted = m_game_manager
+                          ? m_game_manager->requestUserMove(m_pending_from, m_pending_to,
+                                                            /*onClick*/ true)
+                          : false;
+      if (m_pending_promotion != core::PieceType::None && m_game_manager) {
+        m_game_manager->completePendingPromotion(m_pending_promotion);
+        accepted = true;
+      }
 
       if (!accepted) {
         // Roll back visuals to the last known state; cancel the chain
         m_game_view.setBoardFen(m_fen_history.back());
         clearPremove();
       } else {
-        if (m_pending_promotion != core::PieceType::None) {
-          m_game_manager->completePendingPromotion(m_pending_promotion);
-        }
 
         // IMPORTANT: Do NOT pop the queue here — it was already popped when
         // scheduling in movePieceAndClear(). Just rebuild highlights/ghosts for

--- a/src/lilia/view/animation/chess_animator.cpp
+++ b/src/lilia/view/animation/chess_animator.cpp
@@ -44,9 +44,10 @@ void ChessAnimator::dropPiece(core::Square from, core::Square to, core::PieceTyp
 }
 
 void ChessAnimator::promotionSelect(core::Square prPos, PromotionManager& prOptRef, core::Color c) {
+  auto pos = m_board_view_ref.getSquareScreenPos(prPos);
+  bool upwards = pos.y > m_board_view_ref.getPosition().y;
   m_anim_manager.add(m_piece_manager_ref.getPieceID(core::NO_SQUARE),
-                     std::make_unique<PromotionSelectAnim>(
-                         m_board_view_ref.getSquareScreenPos(prPos), prOptRef, c));
+                     std::make_unique<PromotionSelectAnim>(pos, prOptRef, c, upwards));
 }
 
 void ChessAnimator::piecePlaceHolder(core::Square sq) {

--- a/src/lilia/view/animation/promotion_select_animation.cpp
+++ b/src/lilia/view/animation/promotion_select_animation.cpp
@@ -7,9 +7,9 @@
 namespace lilia::view::animation {
 
 PromotionSelectAnim::PromotionSelectAnim(Entity::Position prPos, PromotionManager& prOptRef,
-                                         core::Color c)
+                                         core::Color c, bool upwards)
     : m_promo_pos(prPos), m_promo_mgr_ref(prOptRef) {
-  m_promo_mgr_ref.fillOptions(prPos, c);
+  m_promo_mgr_ref.fillOptions(prPos, c, upwards);
 
   m_white_boarder.setTexture(TextureTable::getInstance().get(constant::STR_TEXTURE_PROMOTION));
   m_white_boarder.setOriginToCenter();

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -119,11 +119,14 @@ void GameView::render() {
   m_piece_manager.renderPieces(m_window, m_chess_animator);
   m_highlight_manager.renderAttack(m_window);
 
-  // Animations in the middle
-  m_chess_animator.render(m_window);
-
-  // GHOSTS on top — fixes "real+ghost at same time"
-  m_piece_manager.renderPremoveGhosts(m_window, m_chess_animator);
+  // Animations and ghosts: ensure promotion overlay stays on top
+  if (isInPromotionSelection()) {
+    m_piece_manager.renderPremoveGhosts(m_window, m_chess_animator);
+    m_chess_animator.render(m_window);
+  } else {
+    m_chess_animator.render(m_window);
+    m_piece_manager.renderPremoveGhosts(m_window, m_chess_animator);
+  }
 
   m_board_view.renderHistoryOverlay(m_window);
   if (m_show_clocks) {

--- a/src/lilia/view/promotion_manager.cpp
+++ b/src/lilia/view/promotion_manager.cpp
@@ -9,15 +9,20 @@ bool PromotionManager::hasOptions() {
 }
 Entity::Position PromotionManager::getCenterPosition() {
   if (m_promotions.empty()) return {0.f, 0.f};
-  return m_promotions[2].getPosition() - Entity::Position{0.f, constant::SQUARE_PX_SIZE * 0.5f};
+  auto first = m_promotions.front().getPosition();
+  auto last = m_promotions.back().getPosition();
+  return {(first.x + last.x) * 0.5f, (first.y + last.y) * 0.5f};
 }
-void PromotionManager::fillOptions(Entity::Position prPos, core::Color c) {
+void PromotionManager::fillOptions(Entity::Position prPos, core::Color c, bool upwards) {
   removeOptions();
   constexpr core::PieceType promotionTypes[] = {core::PieceType::Knight, core::PieceType::Bishop,
                                                 core::PieceType::Rook, core::PieceType::Queen};
 
   for (std::size_t i = 0; i < std::size(promotionTypes); i++) {
-    Entity::Position pos = {prPos.x, prPos.y + i * constant::SQUARE_PX_SIZE};
+    float offset = static_cast<float>(i) * constant::SQUARE_PX_SIZE;
+    Entity::Position pos =
+        upwards ? Entity::Position{prPos.x, prPos.y - offset}
+                 : Entity::Position{prPos.x, prPos.y + offset};
     m_promotions.push_back(Promotion(pos, promotionTypes[i], c));
   }
 }


### PR DESCRIPTION
## Summary
- Ensure premove promotions finalize rather than cancelling
- Draw premove ghosts below promotion selector
- Position promotion selector upwards when promoting near bottom

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c68650308329bb80e951f80c8d5c