### PR TITLE
Remove move history overlay

### DIFF
--- a/include/lilia/view/board_view.hpp
+++ b/include/lilia/view/board_view.hpp
@@ -14,7 +14,6 @@ public:
 
   void init();
   void renderBoard(sf::RenderWindow &window);
-  void renderHistoryOverlay(sf::RenderWindow &window);
   [[nodiscard]] Entity::Position getSquareScreenPos(core::Square sq) const;
   void toggleFlipped();
   void setFlipped(bool flipped);
@@ -24,8 +23,6 @@ public:
                                  Entity::Position pieceSize = {0.f, 0.f}) const noexcept;
   [[nodiscard]] core::Square mousePosToSquare(core::MousePos mousePos) const;
 
-  void setHistoryOverlay(bool show);
-
   void setPosition(const Entity::Position &pos);
   [[nodiscard]] Entity::Position getPosition() const;
 
@@ -34,8 +31,6 @@ private:
   Entity::Position m_flip_pos{};
   float m_flip_size{0.f};
   bool m_flipped{false};
-  Entity m_history_overlay;
-  bool m_show_history_overlay{false};
 };
 
 } // namespace lilia::view

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -44,7 +44,6 @@ class GameView {
   void updateFen(const std::string &fen);
   void scrollMoveList(float delta);
   void setBotMode(bool anyBot);
-  void setHistoryOverlay(bool show);
 
   [[nodiscard]] std::size_t getMoveIndexAt(core::MousePos mousePos) const;
   [[nodiscard]] MoveListView::Option getOptionAt(core::MousePos mousePos) const;

--- a/include/lilia/view/render_constants.hpp
+++ b/include/lilia/view/render_constants.hpp
@@ -49,7 +49,6 @@ const std::string STR_TEXTURE_CAPTUREHLIGHT = "captureHighlight";
 const std::string STR_TEXTURE_HOVERHLIGHT = "hoverHighlight";
 const std::string STR_TEXTURE_PREMOVEHLIGHT = "premoveHighlight";
 const std::string STR_TEXTURE_WARNINGHLIGHT = "warningHighlight";
-const std::string STR_TEXTURE_HISTORY_OVERLAY = "historyOverlay";
 
 const std::string STR_FILE_PATH_HAND_OPEN = "assets/icons/cursor_hand_open.png";
 const std::string STR_FILE_PATH_HAND_CLOSED = "assets/icons/cursor_hand_closed.png";

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -64,7 +64,6 @@ GameController::GameController(view::GameView &gView, model::ChessGame &game)
     // If the user is viewing history, jump back to head before applying
     if (this->m_fen_index != this->m_fen_history.size() - 1) {
       this->m_fen_index = this->m_fen_history.size() - 1;
-      this->m_game_view.setHistoryOverlay(false);
       this->m_game_view.setBoardFen(this->m_fen_history[this->m_fen_index]);
       this->m_eval_cp.store(this->m_eval_history[this->m_fen_index]);
       this->m_game_view.updateEval(this->m_eval_history[this->m_fen_index]);
@@ -91,7 +90,6 @@ GameController::GameController(view::GameView &gView, model::ChessGame &game)
     this->m_fen_history.push_back(this->m_chess_game.getFen());
     this->m_eval_history.push_back(this->m_eval_cp.load());
     this->m_fen_index = this->m_fen_history.size() - 1;
-    this->m_game_view.setHistoryOverlay(false);
     this->m_game_view.updateFen(this->m_fen_history.back());
     this->m_game_view.selectMove(this->m_fen_index ? this->m_fen_index - 1
                                                    : static_cast<std::size_t>(-1));
@@ -157,7 +155,6 @@ void GameController::startGame(const std::string &fen, bool whiteIsBot, bool bla
   m_fen_history.push_back(fen);
   m_eval_history.push_back(m_eval_cp.load());
   m_fen_index = 0;
-  m_game_view.setHistoryOverlay(false);
   m_move_history.clear();
   m_game_view.selectMove(static_cast<std::size_t>(-1));
   m_eval_cp.store(m_eval_history[0]);
@@ -301,8 +298,6 @@ void GameController::handleEvent(const sf::Event &event) {
           m_game_view.setClockActive(std::nullopt);
       }
       syncCapturedPieces();
-      m_game_view.setHistoryOverlay(m_chess_game.getResult() == core::GameResult::ONGOING &&
-                                    m_fen_index != m_fen_history.size() - 1);
       return;
     }
   }
@@ -1474,8 +1469,6 @@ void GameController::stepBackward() {
     }
     syncCapturedPieces();
   }
-  m_game_view.setHistoryOverlay(m_chess_game.getResult() == core::GameResult::ONGOING &&
-                                m_fen_index != m_fen_history.size() - 1);
 }
 
 void GameController::stepForward() {
@@ -1547,8 +1540,6 @@ void GameController::stepForward() {
 
   // (Restoration of premove visuals when returning to head now happens
   //  in the animation completion callback above.)
-  m_game_view.setHistoryOverlay(m_chess_game.getResult() == core::GameResult::ONGOING &&
-                                m_fen_index != m_fen_history.size() - 1);
 }
 
 void GameController::resign() {

--- a/src/lilia/view/board_view.cpp
+++ b/src/lilia/view/board_view.cpp
@@ -179,18 +179,12 @@ BoardView::BoardView()
     : m_board({constant::WINDOW_PX_SIZE / 2, constant::WINDOW_PX_SIZE / 2}),
       m_flip_pos(),
       m_flip_size(0.f),
-      m_flipped(false),
-      m_show_history_overlay(false) {}
+      m_flipped(false) {}
 
 void BoardView::init() {
   m_board.init(TextureTable::getInstance().get(constant::STR_TEXTURE_WHITE),
                TextureTable::getInstance().get(constant::STR_TEXTURE_BLACK),
                TextureTable::getInstance().get(constant::STR_TEXTURE_TRANSPARENT));
-  m_history_overlay.setTexture(
-      TextureTable::getInstance().get(constant::STR_TEXTURE_HISTORY_OVERLAY));
-  m_history_overlay.setScale(constant::WINDOW_PX_SIZE, constant::WINDOW_PX_SIZE);
-  m_history_overlay.setOriginToCenter();
-  m_show_history_overlay = false;
   setPosition(getPosition());
 }
 
@@ -211,12 +205,6 @@ void BoardView::renderBoard(sf::RenderWindow& window) {
     const float cx = slot.left + slot.width * 0.5f;
     const float cy = slot.top + slot.height * 0.5f;
     drawTooltip(window, {cx, cy}, "Flip board");
-  }
-}
-
-void BoardView::renderHistoryOverlay(sf::RenderWindow& window) {
-  if (m_show_history_overlay) {
-    m_history_overlay.draw(window);
   }
 }
 
@@ -244,7 +232,6 @@ void BoardView::setFlipped(bool flipped) {
 
 void BoardView::setPosition(const Entity::Position& pos) {
   m_board.setPosition(pos);
-  m_history_overlay.setPosition(pos);
   float iconOffset = constant::SQUARE_PX_SIZE * 0.2f;
   m_flip_size = constant::SQUARE_PX_SIZE * 0.3f;
   m_flip_pos = {pos.x + constant::WINDOW_PX_SIZE / 2.f + iconOffset,
@@ -322,10 +309,6 @@ core::Square BoardView::mousePosToSquare(core::MousePos mousePos) const {
   }
 
   return static_cast<core::Square>(rankFromWhite * 8 + fileFromWhite);
-}
-
-void BoardView::setHistoryOverlay(bool show) {
-  m_show_history_overlay = show;
 }
 
 }  // namespace lilia::view

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -85,7 +85,6 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
 
 void GameView::init(const std::string &fen) {
   m_board_view.init();
-  m_board_view.setHistoryOverlay(false);
   m_piece_manager.initFromFen(fen);
   m_move_list.clear();
   m_eval_bar.reset();
@@ -127,8 +126,6 @@ void GameView::render() {
     m_chess_animator.render(m_window);
     m_piece_manager.renderPremoveGhosts(m_window, m_chess_animator);
   }
-
-  m_board_view.renderHistoryOverlay(m_window);
   if (m_show_clocks) {
     m_top_clock.render(m_window);
     m_bottom_clock.render(m_window);
@@ -201,10 +198,6 @@ void GameView::setBotMode(bool anyBot) {
   m_move_list.setBotMode(anyBot);
 }
 
-void GameView::setHistoryOverlay(bool show) {
-  m_board_view.setHistoryOverlay(show);
-}
-
 std::size_t GameView::getMoveIndexAt(core::MousePos mousePos) const {
   return m_move_list.getMoveIndexAt(
       Entity::Position{static_cast<float>(mousePos.x), static_cast<float>(mousePos.y)});
@@ -217,10 +210,6 @@ MoveListView::Option GameView::getOptionAt(core::MousePos mousePos) const {
 
 void GameView::setGameOver(bool over) {
   m_move_list.setGameOver(over);
-  if (over) {
-    // Ensure move history overlay is hidden when the game is finished
-    m_board_view.setHistoryOverlay(false);
-  }
 }
 
 /* ---------- Modals ---------- */

--- a/src/lilia/view/texture_table.cpp
+++ b/src/lilia/view/texture_table.cpp
@@ -426,8 +426,6 @@ void TextureTable::preLoad() {
        sf::Color(180, 120, 255, 160));  // purple-ish premove highlight
   load(constant::STR_TEXTURE_WARNINGHLIGHT,
        sf::Color(255, 102, 102, 190));  // #FF6666, clear check alert
-  load(constant::STR_TEXTURE_HISTORY_OVERLAY,
-       sf::Color(120, 140, 170, 40));  // #788CAA, subtle last-move
 
   m_textures[constant::STR_TEXTURE_ATTACKHLIGHT] =
       std::move(makeAttackDotTexture(constant::ATTACK_DOT_PX_SIZE));


### PR DESCRIPTION
## Summary
- remove history overlay constant and texture
- strip move history overlay rendering and state handling
- drop controller hooks for move history overlay

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenAL, etc — resolved with package installs; final build fails with undefined X11 references)*
- `cmake --build build` *(fails: undefined reference to XConvertSelection and other X11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d07fb0a88329a6c015e1c3ac26e0