### PR TITLE
Fix ghost piece moving captured piece in premove chains

### DIFF
--- a/src/lilia/view/piece_manager.cpp
+++ b/src/lilia/view/piece_manager.cpp
@@ -295,6 +295,14 @@ void PieceManager::setPremovePiece(core::Square from, core::Square to, core::Pie
       m_premove_origin.erase(itO);
     }
 
+    // If this square held a stashed capture from an earlier step,
+    // drop it now so the captured piece doesn't get resurrected and
+    // accidentally participate in later premoves. Once the ghost
+    // moves on, the replacement is final.
+    if (auto bak = m_captured_backup.find(from); bak != m_captured_backup.end()) {
+      m_captured_backup.erase(bak);
+    }
+
     if (promotion != core::PieceType::None) {
       ghost = makeGhost(promotion, ghost.getColor());
     }


### PR DESCRIPTION
## Summary
- avoid resurrecting previously captured pieces when premove ghosts move again

## Testing
- `cmake ..` (fails: build process did not complete)

------
https://chatgpt.com/codex/tasks/task_e_68b6e519211c8329acadb87a7421e104