### PR TITLE
Clear right-click highlights after moves

### DIFF
--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -789,6 +789,7 @@ void GameController::movePieceAndClear(const model::Move &move, bool isPlayerMov
   if (m_selected_sq == from || m_selected_sq == to) deselectSquare();
   m_preview_active = false;
   m_prev_selected_before_preview = core::NO_SQUARE;
+  m_game_view.clearRightClickHighlights();
 
   // 3) En-passant victim square for visuals
   core::Square epVictimSq = core::NO_SQUARE;


### PR DESCRIPTION
## Summary
- Clear any persistent right-click board highlights after a move finishes

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b700b201488329b6241f2c3a6d63aa