### PR TITLE
Refactor selection and cursor handling

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -20,6 +20,7 @@ class Event;
 #include "../view/game_view.hpp"
 #include "input_manager.hpp"
 #include "time_controller.hpp"
+#include "selection_manager.hpp"
 
 namespace lilia::model {
 class ChessGame;
@@ -105,10 +106,6 @@ private:
 
   void onDrop(core::MousePos start, core::MousePos end);
 
-  void selectSquare(core::Square sq);
-  void deselectSquare();
-  void hoverSquare(core::Square sq);
-  void dehoverSquare();
   void clearPremove();
   bool enqueuePremove(core::Square from, core::Square to);
   void updatePremovePreviews();
@@ -121,8 +118,6 @@ private:
                          bool onClick);
 
   void snapAndReturn(core::Square sq, core::MousePos cur);
-  void highlightLastMove();
-  void clearLastMoveHighlight();
 
   [[nodiscard]] std::vector<core::Square>
   getAttackSquares(core::Square pieceSQ) const;
@@ -173,10 +168,7 @@ private:
   core::PieceType m_pending_promotion = core::PieceType::None;
   bool m_skip_next_move_animation = false;
 
-  core::Square m_selected_sq = core::NO_SQUARE; ///< Currently selected square.
-  core::Square m_hover_sq = core::NO_SQUARE;    ///< Currently hovered square.
-  std::pair<core::Square, core::Square> m_last_move_squares = {
-      core::NO_SQUARE, core::NO_SQUARE}; ///< Last executed move (from -> to).
+  SelectionManager m_selection_manager;
 
   // ---------------- New: GameManager ----------------
   std::unique_ptr<GameManager> m_game_manager;

--- a/include/lilia/controller/selection_manager.hpp
+++ b/include/lilia/controller/selection_manager.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "../chess_types.hpp"
+#include "../view/game_view.hpp"
+
+namespace lilia::controller {
+
+class SelectionManager {
+ public:
+  explicit SelectionManager(view::GameView &view);
+
+  void reset();
+
+  void highlightLastMove() const;
+  void selectSquare(core::Square sq);
+  void deselectSquare();
+  void clearLastMoveHighlight() const;
+  void hoverSquare(core::Square sq);
+  void dehoverSquare();
+
+  void setLastMove(core::Square from, core::Square to);
+  [[nodiscard]] std::pair<core::Square, core::Square> getLastMove() const;
+
+  [[nodiscard]] core::Square getSelectedSquare() const;
+  [[nodiscard]] core::Square getHoveredSquare() const;
+
+ private:
+  view::GameView &m_view;
+  core::Square m_selected_sq;
+  core::Square m_hover_sq;
+  std::pair<core::Square, core::Square> m_last_move_squares;
+};
+
+} // namespace lilia::controller
+

--- a/include/lilia/view/cursor_manager.hpp
+++ b/include/lilia/view/cursor_manager.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <SFML/Window/Cursor.hpp>
+
+namespace sf { class RenderWindow; }
+
+namespace lilia::view {
+
+class CursorManager {
+ public:
+  explicit CursorManager(sf::RenderWindow &window);
+
+  void setDefaultCursor();
+  void setHandOpenCursor();
+  void setHandClosedCursor();
+
+ private:
+  sf::RenderWindow &m_window;
+  sf::Cursor m_cursor_default;
+  sf::Cursor m_cursor_hand_open;
+  sf::Cursor m_cursor_hand_closed;
+};
+
+} // namespace lilia::view
+

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -2,7 +2,6 @@
 
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/System/Vector2.hpp>
-#include <SFML/Window/Cursor.hpp>
 #include <functional>
 #include <optional>
 #include <vector>
@@ -16,6 +15,7 @@
 #include "entity.hpp"
 #include "eval_bar.hpp"
 #include "highlight_manager.hpp"
+#include "cursor_manager.hpp"
 #include "modal_view.hpp"
 #include "move_list_view.hpp"
 #include "particle_system.hpp"
@@ -160,10 +160,7 @@ class GameView {
   // Currently dragged piece (if any)
   core::Square m_dragging_piece{core::NO_SQUARE};
 
-  // cursors
-  sf::Cursor m_cursor_default;
-  sf::Cursor m_cursor_hand_open;
-  sf::Cursor m_cursor_hand_closed;
+  CursorManager m_cursor_manager;
 
   // UI components
   EvalBar m_eval_bar;

--- a/src/lilia/controller/selection_manager.cpp
+++ b/src/lilia/controller/selection_manager.cpp
@@ -1,0 +1,65 @@
+#include "lilia/controller/selection_manager.hpp"
+
+namespace lilia::controller {
+
+SelectionManager::SelectionManager(view::GameView &view)
+    : m_view(view), m_selected_sq(core::NO_SQUARE),
+      m_hover_sq(core::NO_SQUARE),
+      m_last_move_squares{core::NO_SQUARE, core::NO_SQUARE} {}
+
+void SelectionManager::reset() {
+  m_selected_sq = core::NO_SQUARE;
+  m_hover_sq = core::NO_SQUARE;
+  m_last_move_squares = {core::NO_SQUARE, core::NO_SQUARE};
+}
+
+void SelectionManager::highlightLastMove() const {
+  if (m_last_move_squares.first != core::NO_SQUARE)
+    m_view.highlightSquare(m_last_move_squares.first);
+  if (m_last_move_squares.second != core::NO_SQUARE)
+    m_view.highlightSquare(m_last_move_squares.second);
+}
+
+void SelectionManager::selectSquare(core::Square sq) {
+  m_view.highlightSquare(sq);
+  m_selected_sq = sq;
+}
+
+void SelectionManager::deselectSquare() {
+  m_view.clearNonPremoveHighlights();
+  highlightLastMove();
+  m_selected_sq = core::NO_SQUARE;
+}
+
+void SelectionManager::clearLastMoveHighlight() const {
+  if (m_last_move_squares.first != core::NO_SQUARE)
+    m_view.clearHighlightSquare(m_last_move_squares.first);
+  if (m_last_move_squares.second != core::NO_SQUARE)
+    m_view.clearHighlightSquare(m_last_move_squares.second);
+}
+
+void SelectionManager::hoverSquare(core::Square sq) {
+  m_hover_sq = sq;
+  m_view.highlightHoverSquare(m_hover_sq);
+}
+
+void SelectionManager::dehoverSquare() {
+  if (m_hover_sq != core::NO_SQUARE)
+    m_view.clearHighlightHoverSquare(m_hover_sq);
+  m_hover_sq = core::NO_SQUARE;
+}
+
+void SelectionManager::setLastMove(core::Square from, core::Square to) {
+  m_last_move_squares = {from, to};
+}
+
+std::pair<core::Square, core::Square> SelectionManager::getLastMove() const {
+  return m_last_move_squares;
+}
+
+core::Square SelectionManager::getSelectedSquare() const { return m_selected_sq; }
+
+core::Square SelectionManager::getHoveredSquare() const { return m_hover_sq; }
+
+} // namespace lilia::controller
+

--- a/src/lilia/view/cursor_manager.cpp
+++ b/src/lilia/view/cursor_manager.cpp
@@ -1,0 +1,34 @@
+#include "lilia/view/cursor_manager.hpp"
+
+#include <SFML/Graphics/Image.hpp>
+
+#include "lilia/view/render_constants.hpp"
+
+namespace lilia::view {
+
+CursorManager::CursorManager(sf::RenderWindow &window) : m_window(window) {
+  m_cursor_default.loadFromSystem(sf::Cursor::Arrow);
+
+  sf::Image openImg;
+  if (openImg.loadFromFile(constant::STR_FILE_PATH_HAND_OPEN)) {
+    m_cursor_hand_open.loadFromPixels(openImg.getPixelsPtr(), openImg.getSize(),
+                                      {openImg.getSize().x / 3, openImg.getSize().y / 3});
+  }
+
+  sf::Image closedImg;
+  if (closedImg.loadFromFile(constant::STR_FILE_PATH_HAND_CLOSED)) {
+    m_cursor_hand_closed.loadFromPixels(closedImg.getPixelsPtr(), closedImg.getSize(),
+                                        {closedImg.getSize().x / 3, closedImg.getSize().y / 3});
+  }
+
+  m_window.setMouseCursor(m_cursor_default);
+}
+
+void CursorManager::setDefaultCursor() { m_window.setMouseCursor(m_cursor_default); }
+
+void CursorManager::setHandOpenCursor() { m_window.setMouseCursor(m_cursor_hand_open); }
+
+void CursorManager::setHandClosedCursor() { m_window.setMouseCursor(m_cursor_hand_closed); }
+
+} // namespace lilia::view
+

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -1,6 +1,5 @@
 #include "lilia/view/game_view.hpp"
 
-#include <SFML/Graphics/Image.hpp>
 #include <algorithm>
 
 #include "lilia/bot/bot_info.hpp"
@@ -16,6 +15,7 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
       m_highlight_manager(m_board_view),
       m_chess_animator(m_board_view, m_piece_manager),
       m_promotion_manager(),
+      m_cursor_manager(window),
       m_eval_bar(),
       m_move_list(),
       m_top_player(),
@@ -24,22 +24,6 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
       m_bottom_clock(),
       m_modal(),
       m_particles() {
-  // cursors
-  m_cursor_default.loadFromSystem(sf::Cursor::Arrow);
-
-  sf::Image openImg;
-  if (openImg.loadFromFile(constant::STR_FILE_PATH_HAND_OPEN)) {
-    m_cursor_hand_open.loadFromPixels(openImg.getPixelsPtr(), openImg.getSize(),
-                                      {openImg.getSize().x / 3, openImg.getSize().y / 3});
-  }
-  sf::Image closedImg;
-  if (closedImg.loadFromFile(constant::STR_FILE_PATH_HAND_CLOSED)) {
-    // FIX: use closedImg size for hotspot (previously used openImg)
-    m_cursor_hand_closed.loadFromPixels(closedImg.getPixelsPtr(), closedImg.getSize(),
-                                        {closedImg.getSize().x / 3, closedImg.getSize().y / 3});
-  }
-  m_window.setMouseCursor(m_cursor_default);
-
   // players
   PlayerInfo topInfo = topIsBot
                            ? getBotConfig(BotType::Lilia).info
@@ -300,13 +284,13 @@ void GameView::movePiece(core::Square from, core::Square to, core::PieceType pro
 
 /* ---------- Cursors ---------- */
 void GameView::setDefaultCursor() {
-  m_window.setMouseCursor(m_cursor_default);
+  m_cursor_manager.setDefaultCursor();
 }
 void GameView::setHandOpenCursor() {
-  m_window.setMouseCursor(m_cursor_hand_open);
+  m_cursor_manager.setHandOpenCursor();
 }
 void GameView::setHandClosedCursor() {
-  m_window.setMouseCursor(m_cursor_hand_closed);
+  m_cursor_manager.setHandClosedCursor();
 }
 
 /* ---------- Board info ---------- */


### PR DESCRIPTION
## Summary
- extract SelectionManager to encapsulate square selection and highlighting logic
- encapsulate cursor logic in a new CursorManager used by GameView
- adapt GameController and GameView to delegate to the new managers

## Testing
- `cmake ..`
- `cmake --build . --target lilia_engine -j 2`


------
https://chatgpt.com/codex/tasks/task_e_68b75590c05c8329a882dce9fab09aae