### PR TITLE
Start clocks after first move

### DIFF
--- a/include/lilia/controller/time_controller.hpp
+++ b/include/lilia/controller/time_controller.hpp
@@ -25,6 +25,7 @@ class TimeController {
   int m_increment;
   core::Color m_active;
   bool m_running{false};
+  bool m_started{false};
   std::optional<core::Color> m_flagged;
 };
 

--- a/src/lilia/controller/time_controller.cpp
+++ b/src/lilia/controller/time_controller.cpp
@@ -11,6 +11,7 @@ TimeController::TimeController(int baseSeconds, int incSeconds)
 void TimeController::start(core::Color sideToMove) {
   m_active = sideToMove;
   m_running = true;
+  m_started = false;
   m_flagged.reset();
 }
 
@@ -20,10 +21,12 @@ void TimeController::onMove(core::Color mover) {
   float &t = (mover == core::Color::White) ? m_white_time : m_black_time;
   t += static_cast<float>(m_increment);
   m_active = ~mover;
+  if (!m_started)
+    m_started = true;
 }
 
 void TimeController::update(float dt) {
-  if (!m_running || m_flagged)
+  if (!m_running || m_flagged || !m_started)
     return;
   float &t = (m_active == core::Color::White) ? m_white_time : m_black_time;
   t -= dt;
@@ -36,6 +39,7 @@ void TimeController::update(float dt) {
 
 void TimeController::stop() {
   m_running = false;
+  m_started = false;
 }
 
 float TimeController::getTime(core::Color color) const {


### PR DESCRIPTION
## Summary
- Add `m_started` flag to TimeController so clocks stay idle until the first move
- Begin timing only after white completes the opening move while still highlighting the active clock

## Testing
- `cmake -S . -B build` (passes)
- `cmake --build build` (fails: invalid use of incomplete type in cursor_manager.cpp)


------
https://chatgpt.com/codex/tasks/task_e_68b767448b148329a2429bc749a1ca76