### PR TITLE
Use smart pointers and reset engine caches

### DIFF
--- a/include/lilia/engine/engine.hpp
+++ b/include/lilia/engine/engine.hpp
@@ -18,6 +18,10 @@ class Engine {
   explicit Engine(const EngineConfig& cfg = {});
   ~Engine();
 
+  // Clear all internal caches and reset state. Useful when restarting the
+  // engine to avoid any leftover data or undefined behaviour.
+  void reset();
+
   static void init() {
     // Zobrist inner once_flag
     model::Zobrist::init();
@@ -31,7 +35,7 @@ class Engine {
 
  private:
   struct Impl;
-  Impl* pimpl;
+  std::unique_ptr<Impl> pimpl;
 };
 
 }  // namespace lilia::engine

--- a/include/lilia/engine/eval.hpp
+++ b/include/lilia/engine/eval.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <memory>
 
 namespace lilia {
 namespace model {
@@ -26,7 +27,7 @@ class Evaluator final {
 
  private:
   struct Impl;
-  mutable Impl* m_impl = nullptr;
+  mutable std::unique_ptr<Impl> m_impl;
 };
 
 }  // namespace engine

--- a/src/lilia/engine/engine.cpp
+++ b/src/lilia/engine/engine.cpp
@@ -33,12 +33,27 @@ struct Engine::Impl {
   }
 };
 
-Engine::Engine(const EngineConfig& cfg) : pimpl(new Impl(cfg)) {
+Engine::Engine(const EngineConfig& cfg) : pimpl(std::make_unique<Impl>(cfg)) {
   Engine::init();
+  reset();
 }
 
-Engine::~Engine() {
-  delete pimpl;
+Engine::~Engine() = default;
+
+void Engine::reset() {
+  if (!pimpl) return;
+  try {
+    pimpl->tt.clear();
+  } catch (...) {
+  }
+  try {
+    if (pimpl->eval) pimpl->eval->clearCaches();
+  } catch (...) {
+  }
+  try {
+    if (pimpl->search) pimpl->search->clearSearchState();
+  } catch (...) {
+  }
 }
 
 std::optional<model::Move> Engine::find_best_move(model::Position& pos, int maxDepth,

--- a/src/lilia/engine/eval.cpp
+++ b/src/lilia/engine/eval.cpp
@@ -1053,12 +1053,8 @@ struct Evaluator::Impl {
   std::array<PawnEntry, PAWN_SIZE> pawn;
   std::atomic<uint32_t> age{1};
 };
-Evaluator::Evaluator() noexcept {
-  m_impl = new Impl();
-}
-Evaluator::~Evaluator() noexcept {
-  delete m_impl;
-}
+Evaluator::Evaluator() noexcept : m_impl(std::make_unique<Impl>()) {}
+Evaluator::~Evaluator() noexcept = default;
 void Evaluator::clearCaches() const noexcept {
   if (!m_impl) return;
   for (auto& e : m_impl->eval) {


### PR DESCRIPTION
## Summary
- replace raw pimpls with `std::unique_ptr` for safer memory management
- add `Engine::reset` to clear caches and state on restart
- ensure evaluator uses RAII to avoid leaks

## Testing
- `cmake -S . -B build` (fails: Could NOT find VORBIS / FLAC / etc, installed deps)
- `cmake --build build` (fails: undefined references to X11 symbols)


------
https://chatgpt.com/codex/tasks/task_e_68b7e8222cb48329b1f77cd306cb8239