### PR TITLE
Optimize move parsing and PV reconstruction

### DIFF
--- a/src/lilia/engine/search.cpp
+++ b/src/lilia/engine/search.cpp
@@ -13,7 +13,6 @@
 #include <memory>
 #include <mutex>
 #include <thread>
-#include <unordered_set>
 #include <vector>
 
 #include "lilia/engine/config.hpp"
@@ -790,7 +789,8 @@ int Search::negamax(model::Position& pos, int depth, int alpha, int beta, int pl
 
 std::vector<model::Move> Search::build_pv_from_tt(model::Position pos, int max_len) {
   std::vector<model::Move> pv;
-  std::unordered_set<uint64_t> seen;
+  std::vector<uint64_t> seen;
+  seen.reserve(max_len);
   for (int i = 0; i < max_len; ++i) {
     model::TTEntry5 tte{};
     if (!tt.probe_into(pos.hash(), tte)) break;
@@ -801,7 +801,8 @@ std::vector<model::Move> Search::build_pv_from_tt(model::Position pos, int max_l
     pv.push_back(m);
 
     uint64_t h = pos.hash();
-    if (!seen.insert(h).second) break;  // TT-Loop erkannt
+    if (std::find(seen.begin(), seen.end(), h) != seen.end()) break;  // TT-Loop erkannt
+    seen.push_back(h);
   }
   return pv;
 }

--- a/src/lilia/model/chess_game.cpp
+++ b/src/lilia/model/chess_game.cpp
@@ -18,18 +18,20 @@ core::Square stringToSquare(const std::string& strSquare) {
   return static_cast<core::Square>(file + rank * 8);
 }
 
-inline int squareFromUCI(const std::string& sq) {
-  if (sq.size() != 2) return -1;
+inline int squareFromUCI(const char* sq) {
+  if (!sq) return -1;
   int file = sq[0] - 'a';
   int rank = sq[1] - '1';
+  if (file < 0 || file > 7 || rank < 0 || rank > 7) return -1;
   return rank * 8 + file;
 }
 
 void ChessGame::doMoveUCI(const std::string& uciMove) {
   if (uciMove.size() < 4) return;
 
-  int from = squareFromUCI(uciMove.substr(0, 2));
-  int to = squareFromUCI(uciMove.substr(2, 2));
+  const char* ptr = uciMove.c_str();
+  int from = squareFromUCI(ptr);
+  int to = squareFromUCI(ptr + 2);
   core::PieceType promo = core::PieceType::None;
 
   if (uciMove.size() == 5) {


### PR DESCRIPTION
## Summary
- Avoid temporary string allocations when parsing UCI moves by using char pointers.
- Replace hash-based tracking in `build_pv_from_tt` with a lightweight vector search.

## Testing
- `cmake -S . -B build`
- `cmake --build build --target lilia_engine`


------
https://chatgpt.com/codex/tasks/task_e_68b8248b0c6c8329b513671184861857