### PR TITLE
Snap dragged piece back when leaving window

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -147,6 +147,7 @@ class GameController {
   bool m_has_pending_auto_move = false;
 
   core::Square m_drag_from = core::NO_SQUARE;
+  core::MousePos m_last_mouse_pos{};
   bool m_preview_active = false;
   core::Square m_prev_selected_before_preview = core::NO_SQUARE;
   bool m_selection_changed_on_press = false;

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -362,9 +362,15 @@ void GameController::handleEvent(const sf::Event &event) {
       break;
     case sf::Event::LostFocus:
     case sf::Event::MouseLeft:
+      if (m_dragging && isValid(m_drag_from)) {
+        m_game_view.endAnimation(m_drag_from);
+        snapAndReturn(m_drag_from, m_last_mouse_pos);
+      }
       m_mouse_down = false;
       m_dragging = false;
       m_drag_from = core::NO_SQUARE;
+      m_preview_active = false;
+      m_prev_selected_before_preview = core::NO_SQUARE;
       m_game_view.clearDraggingPiece();
       m_game_view.setDefaultCursor();
       break;
@@ -390,6 +396,7 @@ void GameController::onMouseMove(core::MousePos pos) {
 
 void GameController::onMousePressed(core::MousePos pos) {
   m_mouse_down = true;
+  m_last_mouse_pos = pos;
 
   if (m_game_view.isInPromotionSelection()) {
     m_game_view.setHandClosedCursor();
@@ -1094,6 +1101,7 @@ void GameController::onDrag(core::MousePos start, core::MousePos current) {
   const core::Square sqStart = m_game_view.mousePosToSquare(start);
   const core::MousePos clamped = m_game_view.clampPosToBoard(current);
   const core::Square sqMous = m_game_view.mousePosToSquare(clamped);
+  m_last_mouse_pos = clamped;
 
   if (m_game_view.isInPromotionSelection()) return;
   if (!hasVirtualPiece(sqStart)) return;

--- a/src/lilia/controller/input_manager.cpp
+++ b/src/lilia/controller/input_manager.cpp
@@ -46,6 +46,12 @@ void InputManager::processEvent(const sf::Event& event) {
       }
       break;
 
+    case sf::Event::LostFocus:
+    case sf::Event::MouseLeft:
+      m_drag_start.reset();
+      m_dragging = false;
+      break;
+
     default:
       break;
   }


### PR DESCRIPTION
## Summary
- Cancel dragging when the mouse exits the window or focus is lost and snap the piece back to its square
- Track the last mouse position to animate the return of the piece
- Reset input manager drag state on window exit

## Testing
- `cmake -S . -B build`
- `cmake --build build --target lilia_app -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68b8bb68e8088329a806f7a6bd16a0b1