### PR TITLE
Ensure piece drag persists outside window

### DIFF
--- a/include/lilia/controller/input_manager.hpp
+++ b/include/lilia/controller/input_manager.hpp
@@ -25,6 +25,7 @@ class InputManager {
   void setOnDrop(DropCallback cb);
 
   void processEvent(const sf::Event& event);
+  void cancelDrag();
 
  private:
   bool m_dragging = false;                     ///< Indicates whether a drag operation is active.

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -75,6 +75,7 @@ class GameView {
   void clearDraggingPiece();
 
   [[nodiscard]] sf::Vector2u getWindowSize() const;
+  [[nodiscard]] core::MousePos getMousePosition() const;
   [[nodiscard]] Entity::Position getPieceSize(core::Square pos) const;
 
   [[nodiscard]] bool hasPieceOnSquare(core::Square pos) const;

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -360,12 +360,35 @@ void GameController::handleEvent(const sf::Event &event) {
       if (event.mouseButton.button == sf::Mouse::Left)
         onMouseReleased(core::MousePos(event.mouseButton.x, event.mouseButton.y));
       break;
-    case sf::Event::LostFocus:
     case sf::Event::MouseLeft:
+      break;
+    case sf::Event::MouseEntered: {
+      m_mouse_down = sf::Mouse::isButtonPressed(sf::Mouse::Left);
+      if (m_dragging) {
+        core::MousePos mp = m_game_view.getMousePosition();
+        if (!m_mouse_down) {
+          snapAndReturn(m_drag_from, mp);
+          m_dragging = false;
+          m_drag_from = core::NO_SQUARE;
+          m_game_view.clearDraggingPiece();
+          m_input_manager.cancelDrag();
+          m_game_view.setDefaultCursor();
+        } else {
+          m_game_view.setPieceToMouseScreenPos(m_drag_from, mp);
+        }
+      }
+      break;
+    }
+    case sf::Event::LostFocus:
       m_mouse_down = false;
-      m_dragging = false;
-      m_drag_from = core::NO_SQUARE;
-      m_game_view.clearDraggingPiece();
+      if (m_dragging) {
+        core::MousePos mp = m_game_view.getMousePosition();
+        snapAndReturn(m_drag_from, mp);
+        m_dragging = false;
+        m_drag_from = core::NO_SQUARE;
+        m_game_view.clearDraggingPiece();
+        m_input_manager.cancelDrag();
+      }
       m_game_view.setDefaultCursor();
       break;
     default:

--- a/src/lilia/controller/input_manager.cpp
+++ b/src/lilia/controller/input_manager.cpp
@@ -51,6 +51,11 @@ void InputManager::processEvent(const sf::Event& event) {
   }
 }
 
+void InputManager::cancelDrag() {
+  m_dragging = false;
+  m_drag_start.reset();
+}
+
 [[nodiscard]] bool InputManager::isClick(const core::MousePos& start, const core::MousePos& end,
                                          int threshold) const {
   int dx = end.x - start.x;

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include <SFML/Window/Mouse.hpp>
 #include "lilia/bot/bot_info.hpp"
 #include "lilia/view/render_constants.hpp"
 #include "lilia/view/texture_table.hpp"
@@ -296,6 +297,11 @@ void GameView::setHandClosedCursor() {
 /* ---------- Board info ---------- */
 sf::Vector2u GameView::getWindowSize() const {
   return m_window.getSize();
+}
+
+core::MousePos GameView::getMousePosition() const {
+  sf::Vector2i mp = sf::Mouse::getPosition(m_window);
+  return core::MousePos(static_cast<unsigned>(mp.x), static_cast<unsigned>(mp.y));
 }
 
 Entity::Position GameView::getPieceSize(core::Square pos) const {


### PR DESCRIPTION
## Summary
- Track and reset InputManager drag state with a new `cancelDrag` method
- Expose current mouse position from `GameView`
- Maintain dragging state when the cursor leaves the window and snap back if released outside

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68b8c28d43508329b7be72e787f41db1