### PR TITLE
Flip eval bar with board orientation

### DIFF
--- a/include/lilia/view/eval_bar.hpp
+++ b/include/lilia/view/eval_bar.hpp
@@ -25,6 +25,8 @@ class EvalBar : Entity {
   void toggleVisibility();
   [[nodiscard]] bool isOnToggle(core::MousePos mousePos) const;
 
+  void setFlipped(bool flipped);
+
  private:
   void scaleToEval(float e);
   Entity m_black_background;
@@ -38,6 +40,7 @@ class EvalBar : Entity {
   float m_target_eval{0.f};
   bool m_has_result{false};
   std::string m_result;
+  bool m_flipped{false};
 };
 
 }  // namespace lilia::view

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -60,6 +60,7 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
 
   // board orientation
   m_board_view.setFlipped(flipped);
+  m_eval_bar.setFlipped(flipped);
 
   // initial layout
   layout(m_window.getSize().x, m_window.getSize().y);
@@ -310,6 +311,7 @@ Entity::Position GameView::getPieceSize(core::Square pos) const {
 
 void GameView::toggleBoardOrientation() {
   m_board_view.toggleFlipped();
+  m_eval_bar.setFlipped(m_board_view.isFlipped());
   std::swap(m_top_player, m_bottom_player);
   std::swap(m_white_player, m_black_player);
   std::swap(m_top_clock, m_bottom_clock);


### PR DESCRIPTION
## Summary
- add flipped state to EvalBar with a setter and internal flag
- render eval bar elements based on orientation, including accent strip and text
- synchronize eval bar orientation when board orientation toggles

## Testing
- `cmake ..` *(fails: Could NOT find OpenGL)*


------
https://chatgpt.com/codex/tasks/task_e_68b8f4463904832995669d6e368d87ad