### PR TITLE
Improve endgame popup with centered result and trophy

### DIFF
--- a/include/lilia/view/modal_view.hpp
+++ b/include/lilia/view/modal_view.hpp
@@ -19,7 +19,7 @@ class ModalView {
   bool isResignOpen() const;
 
   // Game over
-  void showGameOver(const std::string& msg, sf::Vector2f centerOnBoard);
+  void showGameOver(const std::string& msg, bool won, sf::Vector2f centerOnBoard);
   void hideGameOver();
   bool isGameOverOpen() const;
 
@@ -69,6 +69,14 @@ class ModalView {
   sf::Text m_title;
   sf::Text m_msg;
 
+  // trophy icon
+  bool m_showTrophy = false;
+  sf::ConvexShape m_trophyCup;
+  sf::RectangleShape m_trophyStem;
+  sf::RectangleShape m_trophyBase;
+  sf::CircleShape m_trophyHandleL;
+  sf::CircleShape m_trophyHandleR;
+
   // buttons (rectangles + labels)
   sf::RectangleShape m_btnLeft, m_btnRight;
   sf::Text m_lblLeft, m_lblRight;
@@ -78,6 +86,7 @@ class ModalView {
 
   // layout helpers
   void layoutCommon(sf::Vector2f center, sf::Vector2f panelSize);
+  void layoutGameOverExtras();
   void stylePrimaryButton(sf::RectangleShape& btn, sf::Text& lbl);
   void styleSecondaryButton(sf::RectangleShape& btn, sf::Text& lbl);
   static inline float snapf(float v) { return std::round(v); }

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -227,8 +227,11 @@ bool GameView::isOnResignNo(core::MousePos mousePos) const {
 
 void GameView::showGameOverPopup(const std::string &msg, bool humanWinner) {
   auto center = m_board_view.getPosition();
-  m_modal.showGameOver(msg, {center.x, center.y});
-  if (humanWinner && msg.find("won") != std::string::npos) {
+  bool won = humanWinner &&
+             (msg.find("won") != std::string::npos ||
+              msg.find("win") != std::string::npos);
+  m_modal.showGameOver(msg, won, {center.x, center.y});
+  if (won) {
     m_particles.emitConfetti(center, static_cast<float>(constant::WINDOW_PX_SIZE), 200);
   }
 }


### PR DESCRIPTION
## Summary
- Center endgame result text and enlarge it
- Add optional SFML trophy icon on wins
- Pass win state to modal and update popup layout
- Emit confetti for time-based victories by detecting both "won" and "wins" messages

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY OPENGL_INCLUDE_DIR))*
- `cmake --build build` *(fails: Makefile: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b92429fcb483299a6bed2444966260