### PR TITLE
Toggle right-click square highlights

### DIFF
--- a/src/lilia/view/highlight_manager.cpp
+++ b/src/lilia/view/highlight_manager.cpp
@@ -63,6 +63,11 @@ void HighlightManager::highlightPremoveSquare(core::Square pos) {
   m_hl_premove_squares[pos] = std::move(newPremove);
 }
 void HighlightManager::highlightRightClickSquare(core::Square pos) {
+  if (auto it = m_hl_rclick_squares.find(pos); it != m_hl_rclick_squares.end()) {
+    m_hl_rclick_squares.erase(it);
+    return;
+  }
+
   Entity newRC(TextureTable::getInstance().get(constant::STR_TEXTURE_RCLICKHLIGHT));
   newRC.setScale(constant::SQUARE_PX_SIZE, constant::SQUARE_PX_SIZE);
   m_hl_rclick_squares[pos] = std::move(newRC);


### PR DESCRIPTION
## Summary
- Allow right-click square highlights to toggle off when the same square is right-clicked again

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f9c5f8348329b9738924f00da872