### PR TITLE
Add right-click arrow highlight feature

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <deque>
 #include <memory>
 #include <string>
@@ -99,7 +100,8 @@ class GameController {
   void onMouseMove(core::MousePos pos);
   void onMousePressed(core::MousePos pos);
   void onMouseReleased(core::MousePos pos);
-  void onRightClick(core::MousePos pos);
+  void onRightPressed(core::MousePos pos);
+  void onRightReleased(core::MousePos pos);
   void onClick(core::MousePos mousePos);
 
   void onDrag(core::MousePos start, core::MousePos current);
@@ -144,9 +146,12 @@ class GameController {
 
   bool m_dragging = false;
   bool m_mouse_down = false;
+  bool m_right_mouse_down = false;
   bool m_has_pending_auto_move = false;
 
   core::Square m_drag_from = core::NO_SQUARE;
+  core::Square m_right_drag_from = core::NO_SQUARE;
+  std::chrono::steady_clock::time_point m_right_press_time{};
   bool m_preview_active = false;
   core::Square m_prev_selected_before_preview = core::NO_SQUARE;
   bool m_selection_changed_on_press = false;

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -99,6 +99,7 @@ class GameView {
   void highlightHoverSquare(core::Square pos);
   void highlightPremoveSquare(core::Square pos);
   void highlightRightClickSquare(core::Square pos);
+  void highlightRightClickArrow(core::Square from, core::Square to);
   void clearHighlightSquare(core::Square pos);
   void clearHighlightHoverSquare(core::Square pos);
   void clearHighlightPremoveSquare(core::Square pos);

--- a/include/lilia/view/highlight_manager.hpp
+++ b/include/lilia/view/highlight_manager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <unordered_map>
+#include <utility>
 
 #include "../chess_types.hpp"
 #include "board_view.hpp"
@@ -17,6 +18,7 @@ class HighlightManager {
   void highlightHoverSquare(core::Square pos);
   void highlightPremoveSquare(core::Square pos);
   void highlightRightClickSquare(core::Square pos);
+  void highlightRightClickArrow(core::Square from, core::Square to);
   void clearAllHighlights();
   void clearNonPremoveHighlights();
   void clearAttackHighlights();
@@ -43,6 +45,8 @@ class HighlightManager {
   std::unordered_map<core::Square, Entity> m_hl_hover_squares;
   std::unordered_map<core::Square, Entity> m_hl_premove_squares;
   std::unordered_map<core::Square, Entity> m_hl_rclick_squares;
+  std::unordered_map<unsigned int, std::pair<core::Square, core::Square>>
+      m_hl_rclick_arrows;
 };
 
 }  // namespace lilia::view

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -414,6 +414,9 @@ void GameView::highlightPremoveSquare(core::Square pos) {
 void GameView::highlightRightClickSquare(core::Square pos) {
   m_highlight_manager.highlightRightClickSquare(pos);
 }
+void GameView::highlightRightClickArrow(core::Square from, core::Square to) {
+  m_highlight_manager.highlightRightClickArrow(from, to);
+}
 
 void GameView::clearHighlightSquare(core::Square pos) {
   m_highlight_manager.clearHighlightSquare(pos);


### PR DESCRIPTION
## Summary
- allow dragging the right mouse button to draw semi-transparent arrows between squares
- tie arrow highlight lifecycle to existing red right-click highlights
- handle right-button press/release in controller to toggle arrows or square highlights

## Testing
- `cmake -S . -B build` *(pass)*
- `cmake --build build --target lilia_app -j2` *(fails: undefined references to X11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fb1b3f488329ad9b5ad92566a4b2