### PR TITLE
Add knight-style arrows and persist right-click highlights

### DIFF
--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -100,6 +100,8 @@ class GameView {
   void highlightPremoveSquare(core::Square pos);
   void highlightRightClickSquare(core::Square pos);
   void highlightRightClickArrow(core::Square from, core::Square to);
+  void stashRightClickHighlights();
+  void restoreRightClickHighlights();
   void clearHighlightSquare(core::Square pos);
   void clearHighlightHoverSquare(core::Square pos);
   void clearHighlightPremoveSquare(core::Square pos);
@@ -180,6 +182,9 @@ class GameView {
 
   // FX
   ParticleSystem m_particles;
+
+  std::vector<core::Square> m_saved_rclick_squares;
+  std::vector<std::pair<core::Square, core::Square>> m_saved_rclick_arrows;
 
   // eval bar toggle handled internally by EvalBar
 };

--- a/include/lilia/view/highlight_manager.hpp
+++ b/include/lilia/view/highlight_manager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "../chess_types.hpp"
 #include "board_view.hpp"
@@ -19,6 +20,9 @@ class HighlightManager {
   void highlightPremoveSquare(core::Square pos);
   void highlightRightClickSquare(core::Square pos);
   void highlightRightClickArrow(core::Square from, core::Square to);
+  [[nodiscard]] std::vector<core::Square> getRightClickSquares() const;
+  [[nodiscard]] std::vector<std::pair<core::Square, core::Square>>
+      getRightClickArrows() const;
   void clearAllHighlights();
   void clearNonPremoveHighlights();
   void clearAttackHighlights();

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -92,6 +92,7 @@ GameController::GameController(view::GameView &gView, model::ChessGame &game)
         this->m_game_view.updateClock(core::Color::Black, tv.black);
         this->m_game_view.setClockActive(tv.active);
       }
+      this->m_game_view.restoreRightClickHighlights();
     }
 
     this->movePieceAndClear(mv, isPlayerMove, onClick);
@@ -288,6 +289,10 @@ void GameController::handleEvent(const sf::Event &event) {
 
       if (leavingFinalState) m_game_view.resetEvalBar();
 
+      if (m_fen_index == m_fen_history.size() - 1 &&
+          idx + 1 != m_fen_history.size() - 1)
+        m_game_view.stashRightClickHighlights();
+
       m_fen_index = idx + 1;
       m_game_view.setBoardFen(m_fen_history[m_fen_index]);
       m_game_view.selectMove(idx);
@@ -314,6 +319,8 @@ void GameController::handleEvent(const sf::Event &event) {
           m_game_view.setClockActive(std::nullopt);
       }
       syncCapturedPieces();
+      if (m_fen_index == m_fen_history.size() - 1)
+        m_game_view.restoreRightClickHighlights();
       return;
     }
   }
@@ -580,6 +587,7 @@ void GameController::update(float dt) {
       if (!accepted) {
         // Roll back visuals to the last known state; cancel the chain
         m_game_view.setBoardFen(m_fen_history.back());
+        m_game_view.restoreRightClickHighlights();
         clearPremove();
       } else {
         // IMPORTANT: Do NOT pop the queue here — it was already popped when
@@ -1500,6 +1508,8 @@ void GameController::stepBackward() {
     const bool leavingFinalState = (m_chess_game.getResult() != core::GameResult::ONGOING &&
                                     m_fen_index == m_fen_history.size() - 1);
 
+    if (m_fen_index == m_fen_history.size() - 1)
+      m_game_view.stashRightClickHighlights();
     m_game_view.setBoardFen(m_fen_history[m_fen_index]);
     const MoveView &info = m_move_history[m_fen_index - 1];
     core::Square epVictim = core::NO_SQUARE;
@@ -1550,6 +1560,8 @@ void GameController::stepBackward() {
         m_game_view.setClockActive(std::nullopt);
     }
     syncCapturedPieces();
+    if (m_fen_index == m_fen_history.size() - 1)
+      m_game_view.restoreRightClickHighlights();
   }
 }
 

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -417,6 +417,16 @@ void GameView::highlightRightClickSquare(core::Square pos) {
 void GameView::highlightRightClickArrow(core::Square from, core::Square to) {
   m_highlight_manager.highlightRightClickArrow(from, to);
 }
+void GameView::stashRightClickHighlights() {
+  m_saved_rclick_squares = m_highlight_manager.getRightClickSquares();
+  m_saved_rclick_arrows = m_highlight_manager.getRightClickArrows();
+}
+void GameView::restoreRightClickHighlights() {
+  for (auto sq : m_saved_rclick_squares)
+    m_highlight_manager.highlightRightClickSquare(sq);
+  for (const auto& ar : m_saved_rclick_arrows)
+    m_highlight_manager.highlightRightClickArrow(ar.first, ar.second);
+}
 
 void GameView::clearHighlightSquare(core::Square pos) {
   m_highlight_manager.clearHighlightSquare(pos);


### PR DESCRIPTION
## Summary
- Draw L-shaped arrows for right-click drags that mimic knight moves
- Preserve right-click square and arrow highlights when navigating the move list

## Testing
- `cmake ..` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68ba01c22b508329b308162c7ee262d1