### PR TITLE
Restore right-click arrows after move list navigation

### DIFF
--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -1630,6 +1630,8 @@ void GameController::stepForward() {
         m_game_view.setClockActive(std::nullopt);
     }
     syncCapturedPieces();
+    if (m_fen_index == m_fen_history.size() - 1)
+      m_game_view.restoreRightClickHighlights();
   }
 
   // (Restoration of premove visuals when returning to head now happens


### PR DESCRIPTION
## Summary
- restore saved right-click arrows and squares when stepping forward back to the latest move

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: undefined references to X11 functions)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1892cb8c83299cd3c19ffc3de6f1