### PR TITLE
Fix palette switching and add themed color selector

### DIFF
--- a/include/lilia/view/start_screen.hpp
+++ b/include/lilia/view/start_screen.hpp
@@ -71,8 +71,8 @@ class StartScreen {
   sf::Text m_creditText;
 
   // Palette selection UI
-  sf::Texture m_paletteTex;
-  sf::Sprite m_paletteIcon;
+  sf::RectangleShape m_paletteButton;
+  sf::Text m_paletteText;
   std::vector<PaletteOption> m_paletteOptions;
   bool m_showPaletteList{false};
 

--- a/src/lilia/view/color_palette_manager.cpp
+++ b/src/lilia/view/color_palette_manager.cpp
@@ -20,7 +20,7 @@ ColorPaletteManager::ColorPaletteManager() {
   registerPalette(constant::STR_COL_PALETTE_DEFAULT, ColorPalette{});
   registerPalette(constant::STR_COL_PALETTE_RED_NOIR, PALETTE_ROSE_NOIR);
 
-  m_active = "default";
+  m_active = constant::STR_COL_PALETTE_DEFAULT;
 }
 
 void ColorPaletteManager::registerPalette(const std::string& name, const ColorPalette& palette) {


### PR DESCRIPTION
## Summary
- Replace palette icon with hoverable "Color Theme" text button using palette colors
- Show palette options with friendly names and enable Red Noir theme
- Track active palette name correctly in `ColorPaletteManager`

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3ac501748329bff1a2f7f7cd4066