### PR TITLE
Delay palette setup until after selection

### DIFF
--- a/src/lilia/view/start_screen.cpp
+++ b/src/lilia/view/start_screen.cpp
@@ -552,13 +552,18 @@ bool StartScreen::handleMouse(sf::Vector2f pos, StartConfig& cfg) {
     return false;
   }
   if (m_showPaletteList) {
+    std::string selectedPalette;
     for (auto& opt : m_paletteOptions) {
       if (contains(opt.box.getGlobalBounds(), pos)) {
-        ColorPaletteManager::get().setPalette(opt.name);
-        setupUI();
-        m_showPaletteList = false;
-        return false;
+        selectedPalette = opt.name;
+        break;
       }
+    }
+    if (!selectedPalette.empty()) {
+      ColorPaletteManager::get().setPalette(selectedPalette);
+      setupUI();
+      m_showPaletteList = false;
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary
- Refactor start screen palette handling to defer UI setup until after a palette option is chosen

## Testing
- `cmake --build build --target lilia_app` *(fails: include/lilia/engine/config.hpp:7:8: error: ‘uint64_t’ in namespace ‘std’ does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_68ba40e2450083299e5738c93dbbff3d