### PR TITLE
Use sentinel piece instead of std::optional for board lookups

### DIFF
--- a/include/lilia/engine/move_order.hpp
+++ b/include/lilia/engine/move_order.hpp
@@ -13,12 +13,16 @@ inline int mvv_lva_fast(const model::Position& pos, const model::Move& m) {
   core::PieceType victimType = core::PieceType::Pawn;
   if (m.isEnPassant()) {
     victimType = core::PieceType::Pawn;
-  } else if (auto vp = b.getPiece(m.to())) {
-    victimType = vp->type;
+  } else {
+    auto vp = b.getPiece(m.to());
+    if (vp.type != core::PieceType::None) {
+      victimType = vp.type;
+    }
   }
 
   core::PieceType attackerType = core::PieceType::Pawn;
-  if (auto ap = b.getPiece(m.from())) attackerType = ap->type;
+  auto ap = b.getPiece(m.from());
+  if (ap.type != core::PieceType::None) attackerType = ap.type;
 
   const int vVictim = base_value[static_cast<int>(victimType)];
   const int vAttacker = base_value[static_cast<int>(attackerType)];

--- a/include/lilia/model/board.hpp
+++ b/include/lilia/model/board.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <array>
-#include <optional>
 
 #include "core/model_types.hpp"
 
@@ -15,7 +14,7 @@ class Board {
   // API unverändert
   void setPiece(core::Square sq, bb::Piece p) noexcept;
   void removePiece(core::Square sq) noexcept;
-  std::optional<bb::Piece> getPiece(core::Square sq) const noexcept;
+  bb::Piece getPiece(core::Square sq) const noexcept;
 
   bb::Bitboard getPieces(core::Color c) const { return m_color_occ[bb::ci(c)]; }
   bb::Bitboard getAllPieces() const { return m_all_occ; }

--- a/src/lilia/model/board.cpp
+++ b/src/lilia/model/board.cpp
@@ -109,9 +109,9 @@ void Board::removePiece(core::Square sq) noexcept {
   m_piece_on[s] = 0;
 }
 
-std::optional<bb::Piece> Board::getPiece(core::Square sq) const noexcept {
+bb::Piece Board::getPiece(core::Square sq) const noexcept {
   const std::uint8_t packed = m_piece_on[static_cast<int>(sq)];
-  if (!packed) return std::nullopt;
+  if (!packed) return {};
   return unpack_piece(packed);
 }
 

--- a/src/lilia/model/chess_game.cpp
+++ b/src/lilia/model/chess_game.cpp
@@ -277,8 +277,7 @@ void ChessGame::setResult(core::GameResult res) {
 }
 
 bb::Piece ChessGame::getPiece(core::Square sq) {
-  auto opt = m_position.getBoard().getPiece(sq);
-  return opt.value_or(bb::Piece{core::PieceType::None, core::Color::White});
+  return m_position.getBoard().getPiece(sq);
 }
 
 void ChessGame::doMove(core::Square from, core::Square to, core::PieceType promotion) {
@@ -311,13 +310,13 @@ std::string ChessGame::getFen() const {
     for (int file = 0; file < 8; ++file) {
       const core::Square sq = static_cast<core::Square>(rank * 8 + file);
       const auto piece = board.getPiece(sq);
-      if (piece.has_value()) {
+      if (piece.type != core::PieceType::None) {
         if (empty) {
           oss << empty;
           empty = 0;
         }
         char ch;
-        switch (piece->type) {
+        switch (piece.type) {
           case core::PieceType::King:
             ch = 'k';
             break;
@@ -340,7 +339,7 @@ std::string ChessGame::getFen() const {
             ch = '?';
             break;
         }
-        if (piece->color == core::Color::White) ch = static_cast<char>(std::toupper(ch));
+        if (piece.color == core::Color::White) ch = static_cast<char>(std::toupper(ch));
         oss << ch;
       } else {
         ++empty;


### PR DESCRIPTION
## Summary
- return `bb::Piece` with a `PieceType::None` sentinel from `Board::getPiece`
- update move ordering, search, and controller logic to check the sentinel instead of `std::optional`
- adjust FEN generation and position handling for the new piece lookup API

## Testing
- `cmake -S . -B build` *(fails: Could NOT find VORBIS)*

------
https://chatgpt.com/codex/tasks/task_e_68ba412671f08329a15482a2f30bd3fd