### PR TITLE
Use constexpr LMR reduction table

### DIFF
--- a/include/lilia/engine/lmr_red.hpp
+++ b/include/lilia/engine/lmr_red.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <cstddef>
 
 namespace lilia::engine {
@@ -6,13 +7,13 @@ namespace lilia::engine {
 constexpr int LMR_MAX_D = 64;  // depth index [0..64]
 constexpr int LMR_MAX_M = 64;  // move-number index [0..64]
 
-// Late Move Reduction lookup table: reductions in plies.
-// Access like: LMR_RED[depth][moveNumber]
-extern int LMR_RED[LMR_MAX_D + 1][LMR_MAX_M + 1];
+using LMRTable = std::array<std::array<int, LMR_MAX_M + 1>, LMR_MAX_D + 1>;
 
-// Build (or rebuild) the table. Call with your own tuning if desired.
-// base: additive bias; scale: overall reduction strength.
-// Typical good defaults: base=0.33, scale=3.6
-void build_LMR_RED(double base = 0.33, double scale = 3.6);
+extern const LMRTable LMR_RED;
+
+// Returns the precomputed Late Move Reduction for a given depth and move number.
+constexpr int lmr_red(int depth, int move) {
+  return LMR_RED[depth][move];
+}
 
 }  // namespace lilia::engine

--- a/src/lilia/engine/lmr_red.cpp
+++ b/src/lilia/engine/lmr_red.cpp
@@ -1,34 +1,28 @@
 #include "lilia/engine/lmr_red.hpp"
 
-#include <cmath>  // std::log
-#include <mutex>  // optional if you call build from multiple threads
+#include <array>
+#include <cmath>
 
 namespace lilia::engine {
 
-alignas(64) int LMR_RED[LMR_MAX_D + 1][LMR_MAX_M + 1];
-
-// Fill table with safe, monotone, bounded reductions.
-// r = floor(base + log(depth) * log(2 + move) / scale)
-// Clamped to [0, depth-1] and 0 for tiny depth/move.
-void build_LMR_RED(double base, double scale) {
+consteval LMRTable build_LMR_RED(double base = 0.33, double scale = 3.6) {
+  LMRTable table{};
   for (int d = 0; d <= LMR_MAX_D; ++d) {
     for (int m = 0; m <= LMR_MAX_M; ++m) {
-      double rd = (d <= 1 || m <= 1) ? 0.0
-                                     : base + std::log(static_cast<double>(d)) *
-                                                  std::log(2.0 + static_cast<double>(m)) / scale;
+      double rd = (d <= 1 || m <= 1)
+                      ? 0.0
+                      : base + std::log(static_cast<double>(d)) *
+                                   std::log(2.0 + static_cast<double>(m)) / scale;
       int r = static_cast<int>(rd);
       if (r < 0) r = 0;
       if (d > 0 && r > d - 1) r = d - 1;
-      LMR_RED[d][m] = r;
+      table[d][m] = r;
     }
   }
+  return table;
 }
 
-// Auto-build with defaults at program start.
-// If you want different coefficients, call build_LMR_RED() once
-// early in your init (before starting the search threads) to overwrite.
-struct LMRInitOnce {
-  LMRInitOnce() { build_LMR_RED(); }
-} static _lmrInitOnce;
+alignas(64) constexpr LMRTable LMR_RED = build_LMR_RED();
 
 }  // namespace lilia::engine
+


### PR DESCRIPTION
## Summary
- precompute late-move reduction table at compile time and remove runtime builder
- provide `lmr_red` constexpr accessor

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: ‘uint64_t’ in namespace ‘std’ does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_68ba47f97f788329b930c57cd568d381