### PR TITLE
Reload textures on palette change

### DIFF
--- a/include/lilia/view/texture_table.hpp
+++ b/include/lilia/view/texture_table.hpp
@@ -18,6 +18,9 @@ class TextureTable {
 
   void preLoad();
 
+  // Reload textures that depend on the current color palette.
+  void reloadForPalette();
+
  private:
   void load(const std::string& name, const sf::Color& color, sf::Vector2u size = {1, 1});
 

--- a/src/lilia/view/color_palette_manager.cpp
+++ b/src/lilia/view/color_palette_manager.cpp
@@ -2,6 +2,7 @@
 
 #include "lilia/view/col_palette/rose_noir.hpp"
 #include "lilia/view/render_constants.hpp"
+#include "lilia/view/texture_table.hpp"
 
 namespace lilia::view {
 
@@ -32,6 +33,7 @@ void ColorPaletteManager::setPalette(const std::string& name) {
   auto it = m_palettes.find(name);
   if (it != m_palettes.end()) {
     loadPalette(it->second);
+    TextureTable::getInstance().reloadForPalette();
     m_active = name;
   }
 }

--- a/src/lilia/view/texture_table.cpp
+++ b/src/lilia/view/texture_table.cpp
@@ -16,6 +16,11 @@ TextureTable::TextureTable() = default;
 
 TextureTable::~TextureTable() = default;
 
+void TextureTable::reloadForPalette() {
+  m_textures.clear();
+  preLoad();
+}
+
 void TextureTable::load(const std::string& name, const sf::Color& color, sf::Vector2u size) {
   auto it = m_textures.find(name);
   if (it != m_textures.end()) return;


### PR DESCRIPTION
## Summary
- Add `reloadForPalette` to TextureTable to rebuild textures when colors change
- Declare and expose reload API to allow external calls
- Invoke texture reload when switching color palettes

## Testing
- `cmake -S . -B build` *(fails: Could NOT find VORBIS FLAC etc? Wait we ended with success? after final we built we attempted compile but fail) But final config success; build `cmake --build build` failed due to missing <cstdint>. For summary we should mention config and build fail.*


------
https://chatgpt.com/codex/tasks/task_e_68ba50f779008329bfe1ac83d7f76693