### PR TITLE
Reserve move storage in ChessGame constructor

### DIFF
--- a/include/lilia/model/chess_game.hpp
+++ b/include/lilia/model/chess_game.hpp
@@ -13,7 +13,7 @@ namespace lilia::model {
 
 class ChessGame {
  public:
-  ChessGame() = default;
+  ChessGame();
 
   void setPosition(const std::string& fen);
   void buildHash();

--- a/src/lilia/model/chess_game.cpp
+++ b/src/lilia/model/chess_game.cpp
@@ -39,6 +39,11 @@ inline core::Square stringToSquare(std::string_view sv) noexcept {
 
 // ---------------- Public API ----------------
 
+ChessGame::ChessGame() {
+  m_pseudo_moves.reserve(256);
+  m_legal_moves.reserve(256);
+}
+
 void ChessGame::doMoveUCI(const std::string& uciMove) {
   const size_t len = uciMove.size();
   if (len < 4) return;


### PR DESCRIPTION
## Summary
- Declare `ChessGame` constructor in header.
- Implement `ChessGame` constructor to pre-reserve pseudo and legal move storage.

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*
- `apt-get install -y libgl1-mesa-dev libglu1-mesa-dev` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6104e2e08329a16f785ea4f32489