### PR TITLE
Use custom parseInt for FEN clocks

### DIFF
--- a/src/lilia/model/chess_game.cpp
+++ b/src/lilia/model/chess_game.cpp
@@ -35,6 +35,15 @@ inline core::Square stringToSquare(std::string_view sv) noexcept {
   return static_cast<core::Square>(file + rank * 8);
 }
 
+inline int parseInt(std::string_view sv) noexcept {
+  int val = 0;
+  for (char c : sv) {
+    if (c < '0' || c > '9') break;
+    val = val * 10 + (c - '0');
+  }
+  return val;
+}
+
 }  // namespace
 
 // ---------------- Public API ----------------
@@ -195,18 +204,11 @@ void ChessGame::setPosition(const std::string& fen) {
   // Clocks (robust parse)
   int hm = 0, fm = 1;
   if (!halfmoveClock.empty()) {
-    try {
-      hm = std::stoi(std::string(halfmoveClock));
-    } catch (...) {
-      hm = 0;
-    }
+    hm = parseInt(halfmoveClock);
   }
   if (!fullmoveNumber.empty()) {
-    try {
-      fm = std::stoi(std::string(fullmoveNumber));
-    } catch (...) {
-      fm = 1;
-    }
+    fm = parseInt(fullmoveNumber);
+    if (fm == 0) fm = 1;
   }
   m_position.getState().halfmoveClock = hm;
   m_position.getState().fullmoveNumber = fm;


### PR DESCRIPTION
## Summary
- add lightweight `parseInt` to accumulate digits until a non-digit
- replace `std::stoi` calls with `parseInt` so malformed FEN clock fields fall back to defaults

## Testing
- `g++ -std=c++23 /tmp/test.cpp src/lilia/model/chess_game.cpp src/lilia/model/magic.cpp src/lilia/model/magic_serializer.cpp src/lilia/model/move_generator.cpp src/lilia/model/position.cpp src/lilia/model/zobrist.cpp -I include -I include/lilia -pthread -D__debugbreak=__builtin_trap -o /tmp/test`
- `/tmp/test`
- `g++ -std=c++23 /tmp/test2.cpp src/lilia/model/chess_game.cpp src/lilia/model/magic.cpp src/lilia/model/magic_serializer.cpp src/lilia/model/move_generator.cpp src/lilia/model/position.cpp src/lilia/model/zobrist.cpp -I include -I include/lilia -pthread -D__debugbreak=__builtin_trap -o /tmp/test2`
- `/tmp/test2`

------
https://chatgpt.com/codex/tasks/task_e_68ba61098e9483299297cb262adc1a40