### PR TITLE
Track position repetition counts

### DIFF
--- a/include/lilia/model/position.hpp
+++ b/include/lilia/model/position.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <vector>
+#include <unordered_map>
 
 #include "../engine/eval_acc.hpp"
 #include "board.hpp"
@@ -44,6 +45,9 @@ class Position {
       }
     }
     m_state.pawnKey = pk;
+
+    repetitionCount.clear();
+    repetitionCount[m_hash] = 1;
   }
 
   // Make/Unmake
@@ -71,6 +75,7 @@ class Position {
   bb::Bitboard m_hash = 0;
   engine::EvalAcc evalAcc_;
   std::vector<NullState> m_null_history;
+  std::unordered_map<bb::Bitboard, int> repetitionCount;
 
   // interne Helfer
   void applyMove(const Move& m, StateInfo& st);

--- a/src/lilia/model/position.cpp
+++ b/src/lilia/model/position.cpp
@@ -85,15 +85,7 @@ bool Position::checkMoveRule() {
 }
 
 bool Position::checkRepetition() {
-  int count = 0;
-  const int n = (int)m_history.size();
-  const int lim = std::min<int>(n, m_state.halfmoveClock);
-  for (int back = 2; back <= lim; back += 2) {
-    const int idx = n - back;
-    if (idx < 0) break;
-    if (m_history[idx].zobristKey == m_hash && ++count >= 2) return true;
-  }
-  return false;
+  return repetitionCount[m_hash] >= 3;
 }
 
 bool Position::inCheck() const {
@@ -420,11 +412,13 @@ bool Position::doMove(const Move& m) {
   }
 
   m_history.push_back(st);
+  repetitionCount[m_hash]++;
   return true;
 }
 
 void Position::undoMove() {
   if (m_history.empty()) return;
+  repetitionCount[m_hash]--;
   StateInfo st = m_history.back();
   unapplyMove(st);
   m_hash = st.zobristKey;
@@ -450,11 +444,13 @@ bool Position::doNullMove() {
   if (m_state.sideToMove == core::Color::White) ++m_state.fullmoveNumber;
 
   m_null_history.push_back(st);
+  repetitionCount[m_hash]++;
   return true;
 }
 
 void Position::undoNullMove() {
   if (m_null_history.empty()) return;
+  repetitionCount[m_hash]--;
   NullState st = m_null_history.back();
   m_null_history.pop_back();
 


### PR DESCRIPTION
## Summary
- Track repetition counts using `std::unordered_map` inside `Position`
- Update move and null-move routines to keep repetition counts in sync
- Simplify repetition detection to a hash map lookup

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*


------
https://chatgpt.com/codex/tasks/task_e_68ba6130d7f0832988a80b9d2859ad71