### PR TITLE
Ensure UI updates on theme changes via palette listeners

### DIFF
--- a/include/lilia/view/clock.hpp
+++ b/include/lilia/view/clock.hpp
@@ -14,6 +14,7 @@ namespace lilia::view {
 class Clock {
  public:
   Clock();
+  ~Clock();
 
   void setPlayerColor(core::Color color);
   void setPosition(const sf::Vector2f& pos);
@@ -40,6 +41,8 @@ class Clock {
   bool m_is_light_theme{false};
   sf::CircleShape m_icon_circle;
   sf::RectangleShape m_icon_hand;
+
+  ColorPaletteManager::ListenerID m_listener_id{0};
 
   void applyFillColor();
 };

--- a/include/lilia/view/color_palette_manager.hpp
+++ b/include/lilia/view/color_palette_manager.hpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <functional>
 
 #include "col_palette/color_palette.hpp"
 
@@ -25,6 +26,11 @@ class ColorPaletteManager {
   PaletteColors& palette() { return m_current; }
   const PaletteColors& defaultPalette() const { return m_default; }
   const std::vector<std::string>& paletteNames() const { return m_order; }
+  const std::string& activePalette() const { return m_active; }
+
+  using ListenerID = std::size_t;
+  ListenerID addListener(std::function<void()> listener);
+  void removeListener(ListenerID id);
 
  private:
   ColorPaletteManager();
@@ -34,6 +40,8 @@ class ColorPaletteManager {
   std::unordered_map<std::string, ColorPalette> m_palettes;
   std::vector<std::string> m_order;
   std::string m_active;
+  std::unordered_map<ListenerID, std::function<void()>> m_listeners;
+  ListenerID m_nextListenerId{0};
 };
 
 }  // namespace lilia::view

--- a/include/lilia/view/modal_view.hpp
+++ b/include/lilia/view/modal_view.hpp
@@ -2,6 +2,7 @@
 #include <math.h>
 
 #include <SFML/Graphics.hpp>
+#include "color_palette_manager.hpp"
 
 namespace lilia::view {
 
@@ -9,6 +10,7 @@ namespace lilia::view {
 class ModalView {
  public:
   ModalView();
+  ~ModalView();
 
   // Must be called once (or let it succeed if already loaded)
   void loadFont(const std::string& fontPath);
@@ -82,6 +84,8 @@ class ModalView {
   void layoutGameOverExtras();
   void stylePrimaryButton(sf::RectangleShape& btn, sf::Text& lbl);
   void styleSecondaryButton(sf::RectangleShape& btn, sf::Text& lbl);
+  void applyTheme();
+  ColorPaletteManager::ListenerID m_listener_id{0};
   static inline float snapf(float v) { return std::round(v); }
 };
 

--- a/include/lilia/view/player_info_view.hpp
+++ b/include/lilia/view/player_info_view.hpp
@@ -9,12 +9,14 @@
 #include "entity.hpp"
 #include "lilia/chess_types.hpp"
 #include "lilia/player_info.hpp"
+#include "color_palette_manager.hpp"
 
 namespace lilia::view {
 
 class PlayerInfoView {
  public:
  PlayerInfoView();
+  ~PlayerInfoView();
 
   void setInfo(const PlayerInfo& info);
   void setPlayerColor(core::Color color);
@@ -38,6 +40,10 @@ class PlayerInfoView {
   core::Color m_playerColor{core::Color::White};
   Entity::Position m_position{};
   std::vector<Entity> m_capturedPieces;
+
+  ColorPaletteManager::ListenerID m_listener_id{0};
+
+  void applyTheme();
 
   void layoutCaptured();
 };

--- a/src/lilia/view/clock.cpp
+++ b/src/lilia/view/clock.cpp
@@ -111,7 +111,15 @@ Clock::Clock() {
   m_text_base_color = constant::COL_LIGHT_TEXT;
   m_is_light_theme = false;
   m_text.setStyle(sf::Text::Style::Bold);
+
+  m_listener_id =
+      ColorPaletteManager::get().addListener([this]() {
+        setPlayerColor(m_is_light_theme ? core::Color::White : core::Color::Black);
+        setActive(m_active);
+      });
 }
+
+Clock::~Clock() { ColorPaletteManager::get().removeListener(m_listener_id); }
 
 void Clock::applyFillColor() {
   if (m_low_time) {

--- a/src/lilia/view/color_palette_manager.cpp
+++ b/src/lilia/view/color_palette_manager.cpp
@@ -35,6 +35,9 @@ void ColorPaletteManager::setPalette(const std::string& name) {
     loadPalette(it->second);
     TextureTable::getInstance().reloadForPalette();
     m_active = name;
+    for (auto& [id, fn] : m_listeners) {
+      if (fn) fn();
+    }
   }
 }
 
@@ -43,5 +46,13 @@ void ColorPaletteManager::loadPalette(const ColorPalette& palette) {
   LILIA_COLOR_PALETTE(X)
 #undef X
 }
+
+ColorPaletteManager::ListenerID ColorPaletteManager::addListener(std::function<void()> listener) {
+  ListenerID id = m_nextListenerId++;
+  m_listeners[id] = std::move(listener);
+  return id;
+}
+
+void ColorPaletteManager::removeListener(ListenerID id) { m_listeners.erase(id); }
 
 }  // namespace lilia::view

--- a/src/lilia/view/modal_view.cpp
+++ b/src/lilia/view/modal_view.cpp
@@ -145,17 +145,6 @@ inline void drawCloseGlyph(sf::RenderTarget& t, const sf::FloatRect& r, bool hov
 // ------------------ Class impl ------------------
 
 ModalView::ModalView() {
-  m_panel.setFillColor(constant::COL_PANEL);
-  m_border.setFillColor(constant::COL_BORDER);
-  m_overlay.setFillColor(constant::COL_OVERLAY);
-
-  m_title.setFillColor(constant::COL_TEXT);
-  m_title.setCharacterSize(20);
-  m_title.setStyle(sf::Text::Bold);
-
-  m_msg.setFillColor(constant::COL_MUTED_TEXT);
-  m_msg.setCharacterSize(16);
-
   m_btnLeft.setSize({120.f, 36.f});
   m_btnRight.setSize({120.f, 36.f});
 
@@ -166,7 +155,13 @@ ModalView::ModalView() {
   // Close button (vector glyph will be drawn; keep text object unused)
   m_lblClose.setCharacterSize(16);
   m_lblClose.setString("");
+
+  applyTheme();
+  m_listener_id =
+      ColorPaletteManager::get().addListener([this]() { applyTheme(); });
 }
+
+ModalView::~ModalView() { ColorPaletteManager::get().removeListener(m_listener_id); }
 
 void ModalView::loadFont(const std::string& fontPath) {
   if (m_font.getInfo().family.empty()) {
@@ -319,6 +314,32 @@ void ModalView::styleSecondaryButton(sf::RectangleShape& btn, sf::Text& lbl) {
   btn.setFillColor(constant::COL_HEADER);
   btn.setOutlineThickness(0.f);
   lbl.setFillColor(constant::COL_TEXT);
+}
+
+void ModalView::applyTheme() {
+  m_panel.setFillColor(constant::COL_PANEL);
+  m_border.setFillColor(constant::COL_BORDER);
+  m_overlay.setFillColor(constant::COL_OVERLAY);
+  m_title.setFillColor(constant::COL_TEXT);
+  m_title.setCharacterSize(20);
+  m_title.setStyle(sf::Text::Bold);
+  m_msg.setFillColor(constant::COL_MUTED_TEXT);
+  m_msg.setCharacterSize(16);
+  m_btnClose.setFillColor(constant::COL_HEADER);
+
+  if (m_openResign) {
+    stylePrimaryButton(m_btnLeft, m_lblLeft);
+    styleSecondaryButton(m_btnRight, m_lblRight);
+  } else if (m_openGameOver) {
+    styleSecondaryButton(m_btnLeft, m_lblLeft);
+    stylePrimaryButton(m_btnRight, m_lblRight);
+  } else {
+    styleSecondaryButton(m_btnLeft, m_lblLeft);
+    styleSecondaryButton(m_btnRight, m_lblRight);
+  }
+  if (m_openGameOver && m_showTrophy) {
+    layoutGameOverExtras();
+  }
 }
 
 // -------- Resign --------

--- a/src/lilia/view/player_info_view.cpp
+++ b/src/lilia/view/player_info_view.cpp
@@ -74,8 +74,6 @@ inline void drawBevelAround(sf::RenderTarget& t, const sf::FloatRect& r, sf::Col
 
 PlayerInfoView::PlayerInfoView() {
   // 32x32 icon frame
-  m_frame.setFillColor(constant::COL_HEADER);
-  m_frame.setOutlineColor(constant::COL_BORDER);
   m_frame.setOutlineThickness(kIconOutline);
   m_frame.setSize({kIconFrameSize, kIconFrameSize});
 
@@ -100,6 +98,14 @@ PlayerInfoView::PlayerInfoView() {
   // let bevel define the edge; remove extra outline thickness on the box
   m_captureBox.setOutlineThickness(0.f);
   m_captureBox.setOutlineColor(sf::Color::Transparent);
+
+  applyTheme();
+  m_listener_id =
+      ColorPaletteManager::get().addListener([this]() { applyTheme(); });
+}
+
+PlayerInfoView::~PlayerInfoView() {
+  ColorPaletteManager::get().removeListener(m_listener_id);
 }
 
 void PlayerInfoView::setPlayerColor(core::Color color) {
@@ -111,6 +117,14 @@ void PlayerInfoView::setPlayerColor(core::Color color) {
     m_captureBox.setFillColor(constant::COL_DARK_BG);
     m_noCaptures.setFillColor(constant::COL_MUTED_TEXT);
   }
+}
+
+void PlayerInfoView::applyTheme() {
+  m_frame.setFillColor(constant::COL_HEADER);
+  m_frame.setOutlineColor(constant::COL_BORDER);
+  m_name.setFillColor(constant::COL_TEXT);
+  m_elo.setFillColor(constant::COL_MUTED_TEXT);
+  setPlayerColor(m_playerColor);
 }
 
 void PlayerInfoView::setInfo(const PlayerInfo& info) {


### PR DESCRIPTION
## Summary
- add listener API to ColorPaletteManager for theme change notifications
- update clocks, player info, and modal views to refresh colors when palette changes

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*
- `apt-get install -y libgl1-mesa-dev` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ba61a2954c8329905b12dcbb32c545