### PR TITLE
Clear TT before starting search

### DIFF
--- a/src/lilia/engine/engine.cpp
+++ b/src/lilia/engine/engine.cpp
@@ -58,7 +58,11 @@ std::optional<model::Move> Engine::find_best_move(model::Position& pos, int maxD
                                                   std::shared_ptr<std::atomic<bool>> stop) {
   if (maxDepth <= 0) maxDepth = pimpl->cfg.maxDepth;
 
-  // Suche immer sauber zurücksetzen (Killers/History etc.)
+  // Suche immer sauber zurücksetzen (TT, Killers/History etc.)
+  try {
+    pimpl->tt.clear();
+  } catch (...) {
+  }
   try {
     pimpl->search->clearSearchState();
   } catch (...) {


### PR DESCRIPTION
## Summary
- Reset transposition table before each search so previous entries don't leak between searches
- Ensure search heuristics (killers, history, counters) are cleared prior to searching

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68ba6b8010288329b5fcbc5a370af4f3