### PR TITLE
Use string_view for palette constants

### DIFF
--- a/include/lilia/view/color_palette_manager.hpp
+++ b/include/lilia/view/color_palette_manager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 #include <functional>
@@ -13,10 +14,10 @@ class ColorPaletteManager {
   static ColorPaletteManager& get();
 
   // Register a named palette that can be selected later
-  void registerPalette(const std::string& name, const ColorPalette& palette);
+  void registerPalette(std::string_view name, const ColorPalette& palette);
 
   // Activate a palette by name
-  void setPalette(const std::string& name);
+  void setPalette(std::string_view name);
 
   // Load a new palette directly; unspecified colors fall back to defaults
   void loadPalette(const ColorPalette& palette);

--- a/include/lilia/view/render_constants.hpp
+++ b/include/lilia/view/render_constants.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <SFML/Graphics/Color.hpp>
+#include <string_view>
 
 #include "../constants.hpp"
 #include "color_palette_manager.hpp"
@@ -41,8 +42,8 @@ constexpr float ANIM_MOVE_SPEED = .05f;
 #define X(name, defaultValue) inline sf::Color& name = ColorPaletteManager::get().palette().name;
 LILIA_COLOR_PALETTE(X)
 #undef X
-const std::string STR_COL_PALETTE_DEFAULT = "default_col";
-const std::string STR_COL_PALETTE_ROSE_NOIR = "rose_noir_col";
+inline constexpr std::string_view STR_COL_PALETTE_DEFAULT{"default_col"};
+inline constexpr std::string_view STR_COL_PALETTE_ROSE_NOIR{"rose_noir_col"};
 
 const std::string STR_TEXTURE_WHITE = "white";
 const std::string STR_TEXTURE_BLACK = "black";

--- a/src/lilia/view/color_palette_manager.cpp
+++ b/src/lilia/view/color_palette_manager.cpp
@@ -24,17 +24,19 @@ ColorPaletteManager::ColorPaletteManager() {
   m_active = constant::STR_COL_PALETTE_DEFAULT;
 }
 
-void ColorPaletteManager::registerPalette(const std::string& name, const ColorPalette& palette) {
-  if (!m_palettes.count(name)) m_order.push_back(name);
-  m_palettes[name] = palette;
+void ColorPaletteManager::registerPalette(std::string_view name, const ColorPalette& palette) {
+  std::string key{name};
+  if (!m_palettes.count(key)) m_order.push_back(key);
+  m_palettes[std::move(key)] = palette;
 }
 
-void ColorPaletteManager::setPalette(const std::string& name) {
-  auto it = m_palettes.find(name);
+void ColorPaletteManager::setPalette(std::string_view name) {
+  std::string key{name};
+  auto it = m_palettes.find(key);
   if (it != m_palettes.end()) {
     loadPalette(it->second);
     TextureTable::getInstance().reloadForPalette();
-    m_active = name;
+    m_active = std::move(key);
     for (auto& [id, fn] : m_listeners) {
       if (fn) fn();
     }


### PR DESCRIPTION
## Summary
- avoid dynamic initialization by switching palette identifiers to `inline constexpr std::string_view`
- accept `std::string_view` in `ColorPaletteManager` palette registration and selection methods

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*


------
https://chatgpt.com/codex/tasks/task_e_68ba711ad3088329bcfe295d2b21e750