### PR TITLE
Fix palette update to refresh active colors

### DIFF
--- a/include/lilia/view/eval_bar.hpp
+++ b/include/lilia/view/eval_bar.hpp
@@ -15,6 +15,7 @@ namespace lilia::view {
 class EvalBar : Entity {
  public:
   EvalBar();
+  ~EvalBar();
 
   virtual void setPosition(const Entity::Position &pos) override;
   void render(sf::RenderWindow &window);
@@ -41,6 +42,9 @@ class EvalBar : Entity {
   bool m_has_result{false};
   std::string m_result;
   bool m_flipped{false};
+
+  ColorPaletteManager::ListenerID m_paletteListener{0};
+  void onPaletteChanged();
 };
 
 }  // namespace lilia::view

--- a/include/lilia/view/move_list_view.hpp
+++ b/include/lilia/view/move_list_view.hpp
@@ -13,8 +13,9 @@
 namespace lilia::view {
 
 class MoveListView {
-public:
+ public:
   MoveListView();
+  ~MoveListView();
 
   void setPosition(const Entity::Position &pos);
   void setSize(unsigned int width, unsigned int height);
@@ -35,7 +36,7 @@ public:
   [[nodiscard]] Option getOptionAt(const Entity::Position &pos) const;
   void setGameOver(bool over);
 
-private:
+ private:
   sf::Font m_font;
   std::vector<std::string> m_lines;
   std::string m_result;
@@ -65,6 +66,12 @@ private:
   sf::FloatRect m_bounds_new_bot{};
   sf::FloatRect m_bounds_rematch{};
   sf::FloatRect m_bounds_fen_icon{};
+
+  // Palette
+  ColorPaletteManager::ListenerID m_paletteListener{0};
+  sf::Color m_toastTextColor{constant::COL_TEXT};
+
+  void onPaletteChanged();
 };
 
 } // namespace lilia::view

--- a/include/lilia/view/particle_system.hpp
+++ b/include/lilia/view/particle_system.hpp
@@ -5,10 +5,14 @@
 #include <SFML/System/Vector2.hpp>
 #include <vector>
 
+#include "render_constants.hpp"
+
 namespace lilia::view {
 
 class ParticleSystem {
-public:
+ public:
+  ParticleSystem();
+  ~ParticleSystem();
   struct Particle {
     sf::CircleShape shape;
     sf::Vector2f velocity;
@@ -29,6 +33,9 @@ public:
 
 private:
   std::vector<Particle> m_particles;
+  ColorPaletteManager::ListenerID m_paletteListener{0};
+
+  void onPaletteChanged();
 };
 
 } // namespace lilia::view

--- a/src/lilia/view/clock.cpp
+++ b/src/lilia/view/clock.cpp
@@ -176,7 +176,7 @@ void Clock::setTime(float seconds) {
   m_text.setString(formatTime(seconds));
   m_low_time = seconds <= 20.f;
   if (m_low_time) {
-    m_text.setFillColor(sf::Color::White);
+    m_text.setFillColor(constant::COL_LIGHT_TEXT);
   } else {
     m_text.setFillColor(m_text_base_color);
   }

--- a/src/lilia/view/color_palette_manager.cpp
+++ b/src/lilia/view/color_palette_manager.cpp
@@ -35,11 +35,7 @@ void ColorPaletteManager::setPalette(std::string_view name) {
   auto it = m_palettes.find(key);
   if (it != m_palettes.end()) {
     loadPalette(it->second);
-    TextureTable::getInstance().reloadForPalette();
     m_active = std::move(key);
-    for (auto& [id, fn] : m_listeners) {
-      if (fn) fn();
-    }
   }
 }
 
@@ -47,6 +43,11 @@ void ColorPaletteManager::loadPalette(const ColorPalette& palette) {
 #define X(name, defaultValue) m_current.name = palette.name.value_or(m_default.name);
   LILIA_COLOR_PALETTE(X)
 #undef X
+
+  TextureTable::getInstance().reloadForPalette();
+  for (auto& [id, fn] : m_listeners) {
+    if (fn) fn();
+  }
 }
 
 ColorPaletteManager::ListenerID ColorPaletteManager::addListener(std::function<void()> listener) {

--- a/src/lilia/view/eval_bar.cpp
+++ b/src/lilia/view/eval_bar.cpp
@@ -107,11 +107,16 @@ EvalBar::EvalBar() : EvalBar::Entity() {
 
   m_score_text.setFont(m_font);
   m_score_text.setCharacterSize(constant::EVAL_BAR_FONT_SIZE);
-  m_score_text.setFillColor(sf::Color::Black);  // default (balanced → white side)
+  m_score_text.setFillColor(constant::COL_SCORE_TEXT_DARK);  // default (balanced → white side)
 
   m_toggle_text.setFont(m_font);
   m_toggle_text.setCharacterSize(15);
+  m_paletteListener =
+      ColorPaletteManager::get().addListener([this]() { onPaletteChanged(); });
+  onPaletteChanged();
 }
+
+EvalBar::~EvalBar() { ColorPaletteManager::get().removeListener(m_paletteListener); }
 
 void EvalBar::setFlipped(bool flipped) {
   m_flipped = flipped;
@@ -160,7 +165,7 @@ void EvalBar::render(sf::RenderWindow& window) {
     auto tb = m_toggle_text.getLocalBounds();
     m_toggle_text.setOrigin(tb.left + tb.width / 2.f, tb.top + tb.height / 2.f);
     m_toggle_text.setFillColor(hov ? constant::COL_TEXT
-                                  : (m_visible ? sf::Color::Black : constant::COL_TEXT));
+                                  : (m_visible ? constant::COL_SCORE_TEXT_DARK : constant::COL_TEXT));
     m_toggle_text.setPosition(snapf(m_toggle_bounds.left + m_toggle_bounds.width / 2.f),
                               snapf(m_toggle_bounds.top + m_toggle_bounds.height / 2.f - 1.f));
     window.draw(m_toggle_text);
@@ -328,6 +333,11 @@ void EvalBar::setResult(const std::string& result) {
     m_display_eval = m_target_eval = 0.f;
   }
   update(static_cast<int>(m_display_eval));
+}
+
+void EvalBar::onPaletteChanged() {
+  m_score_text.setFillColor(constant::COL_SCORE_TEXT_DARK);
+  m_toggle_text.setFillColor(constant::COL_TEXT);
 }
 
 void EvalBar::reset() {

--- a/src/lilia/view/modal_view.cpp
+++ b/src/lilia/view/modal_view.cpp
@@ -126,7 +126,7 @@ inline void drawCloseGlyph(sf::RenderTarget& t, const sf::FloatRect& r, bool hov
   const float len = std::min(r.width, r.height) * (pressed ? 0.52f : 0.60f);
   const float thick = 2.0f;
 
-  sf::Color col = sf::Color::White;  // accent on hover
+  sf::Color col = constant::COL_LIGHT_TEXT;  // accent on hover
   if (pressed) col = darken(col, 24);
 
   sf::RectangleShape bar({len, thick});
@@ -307,7 +307,7 @@ void ModalView::layoutGameOverExtras() {
 void ModalView::stylePrimaryButton(sf::RectangleShape& btn, sf::Text& lbl) {
   btn.setFillColor(constant::COL_ACCENT);
   btn.setOutlineThickness(0.f);
-  lbl.setFillColor(sf::Color::Black);
+  lbl.setFillColor(constant::COL_DARK_TEXT);
 }
 
 void ModalView::styleSecondaryButton(sf::RectangleShape& btn, sf::Text& lbl) {
@@ -449,9 +449,9 @@ void ModalView::drawPanel(sf::RenderWindow& win) const {
 
   // Accent inset on whichever is primary (filled with COL_ACCENT)
   if (m_btnLeft.getFillColor() == constant::COL_ACCENT)
-    drawAccentInset(win, leftR, sf::Color::White);
+    drawAccentInset(win, leftR, constant::COL_LIGHT_TEXT);
   if (m_btnRight.getFillColor() == constant::COL_ACCENT)
-    drawAccentInset(win, rightR, sf::Color::White);
+    drawAccentInset(win, rightR, constant::COL_LIGHT_TEXT);
 
   // Labels for the main buttons
   win.draw(m_lblLeft);

--- a/src/lilia/view/move_list_view.cpp
+++ b/src/lilia/view/move_list_view.cpp
@@ -301,6 +301,13 @@ std::string ellipsizeRightKeepTail(const std::string& s, sf::Text& probe, float 
 
 MoveListView::MoveListView() {
   m_font.loadFromFile(constant::STR_FILE_PATH_FONT);
+  m_paletteListener =
+      ColorPaletteManager::get().addListener([this]() { onPaletteChanged(); });
+  onPaletteChanged();
+}
+
+MoveListView::~MoveListView() {
+  ColorPaletteManager::get().removeListener(m_paletteListener);
 }
 
 void MoveListView::setPosition(const Entity::Position& pos) {
@@ -708,7 +715,9 @@ void MoveListView::render(sf::RenderWindow& window) const {
       bg.setOutlineColor(outlineCol);
       window.draw(bg);
 
-      msg.setFillColor(sf::Color(255, 255, 255, static_cast<sf::Uint8>(alpha * 255)));
+      sf::Color msgCol = m_toastTextColor;
+      msgCol.a = static_cast<sf::Uint8>(alpha * 255);
+      msg.setFillColor(msgCol);
       msg.setPosition(snapf(pos.x + padX - mb.left), snapf(pos.y + padY - mb.top));
       window.draw(msg);
     }
@@ -799,6 +808,10 @@ MoveListView::Option MoveListView::getOptionAt(const Entity::Position& pos) cons
 
 void MoveListView::setGameOver(bool over) {
   m_game_over = over;
+}
+
+void MoveListView::onPaletteChanged() {
+  m_toastTextColor = constant::COL_TEXT;
 }
 
 }  // namespace lilia::view

--- a/src/lilia/view/particle_system.cpp
+++ b/src/lilia/view/particle_system.cpp
@@ -4,7 +4,18 @@
 #include <cmath>
 #include <random>
 
+#include "lilia/view/render_constants.hpp"
+
 namespace lilia::view {
+
+ParticleSystem::ParticleSystem() {
+  m_paletteListener =
+      ColorPaletteManager::get().addListener([this]() { onPaletteChanged(); });
+}
+
+ParticleSystem::~ParticleSystem() {
+  ColorPaletteManager::get().removeListener(m_paletteListener);
+}
 
 void ParticleSystem::emitConfetti(const sf::Vector2f &center,
                                   const sf::Vector2f &windowSize,
@@ -30,7 +41,7 @@ void ParticleSystem::emitConfetti(const sf::Vector2f &center,
     float radius = radiusDist(rng);
 
     sf::CircleShape shape(radius);
-    shape.setFillColor(sf::Color::White);
+    shape.setFillColor(constant::COL_TEXT);
     shape.setOrigin(radius, radius);
     shape.setPosition({x, startY});
 
@@ -91,5 +102,11 @@ void ParticleSystem::render(sf::RenderWindow &window) {
 void ParticleSystem::clear() { m_particles.clear(); }
 
 bool ParticleSystem::empty() const { return m_particles.empty(); }
+
+void ParticleSystem::onPaletteChanged() {
+  for (auto &p : m_particles) {
+    p.shape.setFillColor(constant::COL_TEXT);
+  }
+}
 
 } // namespace lilia::view

--- a/src/lilia/view/start_screen.cpp
+++ b/src/lilia/view/start_screen.cpp
@@ -325,7 +325,7 @@ void StartScreen::setupUI() {
   m_startText.setFont(m_font);
   m_startText.setString("Start Game");
   m_startText.setCharacterSize(22);
-  m_startText.setFillColor(sf::Color::Black);
+  m_startText.setFillColor(constant::COL_DARK_TEXT);
 
   // Layout anchors
   float x0 = (ws.x - PANEL_W) * 0.5f;
@@ -538,7 +538,7 @@ void StartScreen::applyTheme() {
   m_blackBotText.setFillColor(colText);
 
   m_startBtn.setFillColor(colAccent);
-  m_startText.setFillColor(sf::Color::Black);
+  m_startText.setFillColor(constant::COL_DARK_TEXT);
 
   m_fenErrorText.setFillColor(colInvalid);
   m_fenInputBox.setFillColor(colInput);
@@ -578,7 +578,7 @@ void StartScreen::applyTheme() {
 void StartScreen::updateTimeToggle() {
   if (m_timeEnabled) {
     m_timeToggleBtn.setFillColor(colAccent);
-    m_timeToggleText.setFillColor(sf::Color::Black);
+    m_timeToggleText.setFillColor(constant::COL_DARK_TEXT);
     m_timeToggleText.setString("TIME ON");
   } else {
     m_timeToggleBtn.setFillColor(colTimeOff);


### PR DESCRIPTION
## Summary
- Reload textures and notify listeners when a palette is loaded
- Simplify setPalette to delegate to loadPalette
- Add palette listeners and replace hard-coded colors across view components

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY OPENGL_INCLUDE_DIR))*

------
https://chatgpt.com/codex/tasks/task_e_68ba74e2d51883298ae0c8d8e188265f