### PR TITLE
Rebuild highlight textures on palette change

### DIFF
--- a/include/lilia/view/highlight_manager.hpp
+++ b/include/lilia/view/highlight_manager.hpp
@@ -6,12 +6,14 @@
 #include "../chess_types.hpp"
 #include "board_view.hpp"
 #include "entity.hpp"
+#include "color_palette_manager.hpp"
 
 namespace lilia::view {
 
 class HighlightManager {
  public:
   HighlightManager(const BoardView& boardRef);
+  ~HighlightManager();
 
   void highlightSquare(core::Square pos);
   void highlightAttackSquare(core::Square pos);
@@ -42,6 +44,7 @@ class HighlightManager {
  private:
   void renderEntitiesToBoard(std::unordered_map<core::Square, Entity>& map,
                              sf::RenderWindow& window);
+  void rebuildTextures();
 
   const BoardView& m_board_view_ref;
 
@@ -52,6 +55,7 @@ class HighlightManager {
   std::unordered_map<core::Square, Entity> m_hl_rclick_squares;
   std::unordered_map<unsigned int, std::pair<core::Square, core::Square>>
       m_hl_rclick_arrows;
+  ColorPaletteManager::ListenerID m_palette_listener{};
 };
 
 }  // namespace lilia::view

--- a/src/lilia/view/highlight_manager.cpp
+++ b/src/lilia/view/highlight_manager.cpp
@@ -18,7 +18,46 @@ HighlightManager::HighlightManager(const BoardView& boardRef)
       m_hl_hover_squares(),
       m_hl_premove_squares(),
       m_hl_rclick_squares(),
-      m_hl_rclick_arrows() {}
+      m_hl_rclick_arrows() {
+  m_palette_listener =
+      ColorPaletteManager::get().addListener([this]() { rebuildTextures(); });
+}
+
+HighlightManager::~HighlightManager() {
+  ColorPaletteManager::get().removeListener(m_palette_listener);
+}
+
+void HighlightManager::rebuildTextures() {
+  auto& table = TextureTable::getInstance();
+  for (auto& kv : m_hl_select_squares) {
+    auto& entity = kv.second;
+    entity.setTexture(table.get(constant::STR_TEXTURE_SELECTHLIGHT));
+    entity.setScale(constant::SQUARE_PX_SIZE, constant::SQUARE_PX_SIZE);
+  }
+  for (auto& kv : m_hl_attack_squares) {
+    auto& entity = kv.second;
+    auto size = entity.getOriginalSize();
+    if (size.x < static_cast<float>(constant::SQUARE_PX_SIZE)) {
+      entity.setTexture(table.get(constant::STR_TEXTURE_ATTACKHLIGHT));
+    } else {
+      entity.setTexture(table.get(constant::STR_TEXTURE_CAPTUREHLIGHT));
+    }
+  }
+  for (auto& kv : m_hl_hover_squares) {
+    auto& entity = kv.second;
+    entity.setTexture(table.get(constant::STR_TEXTURE_HOVERHLIGHT));
+  }
+  for (auto& kv : m_hl_premove_squares) {
+    auto& entity = kv.second;
+    entity.setTexture(table.get(constant::STR_TEXTURE_PREMOVEHLIGHT));
+    entity.setScale(constant::SQUARE_PX_SIZE, constant::SQUARE_PX_SIZE);
+  }
+  for (auto& kv : m_hl_rclick_squares) {
+    auto& entity = kv.second;
+    entity.setTexture(table.get(constant::STR_TEXTURE_RCLICKHLIGHT));
+    entity.setScale(constant::SQUARE_PX_SIZE, constant::SQUARE_PX_SIZE);
+  }
+}
 
 void HighlightManager::renderEntitiesToBoard(std::unordered_map<core::Square, Entity>& map,
                                              sf::RenderWindow& window) {


### PR DESCRIPTION
## Summary
- register a ColorPaletteManager listener in HighlightManager and clean it up in the destructor
- rebuild highlight square textures whenever the color palette changes

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68ba7a885e748329b536d33a8cbd84e0