### PR TITLE
Reload textures in place on palette change

### DIFF
--- a/include/lilia/view/board_view.hpp
+++ b/include/lilia/view/board_view.hpp
@@ -4,16 +4,18 @@
 
 #include "../controller/mousepos.hpp"
 #include "board.hpp"
+#include "color_palette_manager.hpp"
 #include "entity.hpp"
 
 namespace lilia::view {
 
 class BoardView {
-public:
+ public:
   BoardView();
+  ~BoardView();
 
   void init();
-  void renderBoard(sf::RenderWindow &window);
+  void renderBoard(sf::RenderWindow& window);
   [[nodiscard]] Entity::Position getSquareScreenPos(core::Square sq) const;
   void toggleFlipped();
   void setFlipped(bool flipped);
@@ -23,14 +25,17 @@ public:
                                  Entity::Position pieceSize = {0.f, 0.f}) const noexcept;
   [[nodiscard]] core::Square mousePosToSquare(core::MousePos mousePos) const;
 
-  void setPosition(const Entity::Position &pos);
+  void setPosition(const Entity::Position& pos);
   [[nodiscard]] Entity::Position getPosition() const;
 
-private:
+ private:
+  void onPaletteChanged();
+
   Board m_board;
   Entity::Position m_flip_pos{};
   float m_flip_size{0.f};
   bool m_flipped{false};
+  ColorPaletteManager::ListenerID m_paletteListener{};
 };
 
-} // namespace lilia::view
+}  // namespace lilia::view

--- a/src/lilia/view/board_view.cpp
+++ b/src/lilia/view/board_view.cpp
@@ -171,13 +171,28 @@ BoardView::BoardView()
     : m_board({constant::WINDOW_PX_SIZE / 2, constant::WINDOW_PX_SIZE / 2}),
       m_flip_pos(),
       m_flip_size(0.f),
-      m_flipped(false) {}
+      m_flipped(false) {
+  m_paletteListener =
+      ColorPaletteManager::get().addListener([this]() { onPaletteChanged(); });
+}
+
+BoardView::~BoardView() {
+  ColorPaletteManager::get().removeListener(m_paletteListener);
+}
 
 void BoardView::init() {
   m_board.init(TextureTable::getInstance().get(constant::STR_TEXTURE_WHITE),
                TextureTable::getInstance().get(constant::STR_TEXTURE_BLACK),
                TextureTable::getInstance().get(constant::STR_TEXTURE_TRANSPARENT));
   setPosition(getPosition());
+}
+
+void BoardView::onPaletteChanged() {
+  auto pos = getPosition();
+  m_board.init(TextureTable::getInstance().get(constant::STR_TEXTURE_WHITE),
+               TextureTable::getInstance().get(constant::STR_TEXTURE_BLACK),
+               TextureTable::getInstance().get(constant::STR_TEXTURE_TRANSPARENT));
+  setPosition(pos);
 }
 
 void BoardView::renderBoard(sf::RenderWindow& window) {

--- a/src/lilia/view/eval_bar.cpp
+++ b/src/lilia/view/eval_bar.cpp
@@ -338,6 +338,11 @@ void EvalBar::setResult(const std::string& result) {
 void EvalBar::onPaletteChanged() {
   m_score_text.setFillColor(constant::COL_SCORE_TEXT_DARK);
   m_toggle_text.setFillColor(constant::COL_TEXT);
+  // Refresh textures in case the underlying palette-dependent images changed.
+  m_black_background.setTexture(
+      TextureTable::getInstance().get(constant::STR_TEXTURE_EVAL_BLACK));
+  m_white_fill_eval.setTexture(
+      TextureTable::getInstance().get(constant::STR_TEXTURE_EVAL_WHITE));
 }
 
 void EvalBar::reset() {

--- a/src/lilia/view/texture_table.cpp
+++ b/src/lilia/view/texture_table.cpp
@@ -17,20 +17,20 @@ TextureTable::TextureTable() = default;
 TextureTable::~TextureTable() = default;
 
 void TextureTable::reloadForPalette() {
-  m_textures.clear();
+  // Reload palette-dependent textures without invalidating existing pointers.
+  // Sprites keep references to the sf::Texture objects stored in the map, so
+  // we avoid clearing the container and instead overwrite the texture data of
+  // the existing entries. This keeps the object addresses stable.
   preLoad();
 }
 
 void TextureTable::load(const std::string& name, const sf::Color& color, sf::Vector2u size) {
-  auto it = m_textures.find(name);
-  if (it != m_textures.end()) return;
-
-  sf::Texture texture;
+  // Acquire (or create) the texture entry and replace its pixel data in place
+  // so that any sf::Sprite currently using this texture remains valid.
+  sf::Texture& texture = m_textures[name];
   sf::Image image;
   image.create(size.x, size.y, color);
   texture.loadFromImage(image);
-
-  m_textures[name] = std::move(texture);
 }
 
 [[nodiscard]] const sf::Texture& TextureTable::get(const std::string& filename) {


### PR DESCRIPTION
## Summary
- Reload palette-dependent textures in place to preserve sprite references
- Reinitialize BoardView textures when palette changes
- Refresh EvalBar textures on palette update

## Testing
- `cmake -B build -S .` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7aaab610832999b9696e04f53f88